### PR TITLE
chore(digest): weekly health digest 2026-05-11

### DIFF
--- a/reports/weekly/2026-05-11.md
+++ b/reports/weekly/2026-05-11.md
@@ -1,0 +1,28 @@
+# CaseDive Weekly Digest — 2026-05-11
+
+## Activity (last 7 days)
+- 0 commits — no application code landed this week
+- Last substantive work: retrieval-health pipeline hardening (PRs #13–#15, merged 2026-04-14)
+
+## Open PRs
+- #2 — Install Vercel Speed Insights (draft, vercel[bot], **61 days old**)
+- #1 — Set Up Vercel Web Analytics for Your Project (draft, vercel[bot], **61 days old**)
+
+## Merged this week
+- None
+
+## Hottest files
+- No files changed this week. Prior high-churn areas (from Apr 14 burst): `scripts/collect-production-no-caselaw.js`, `scripts/apply-retrieval-autofix.js`, `.github/workflows/production-retrieval-autofix.yml`, `api/_caseLawRetrieval.js`, `api/_retrievalImprovements.js`.
+
+## Retrieval health (from config)
+Final-selection gate: `final_case_min_token_overlap: 3`; AI citation pre-verify gate: `ai_citation_min_token_overlap: 2`; `relevance_min_score: 4`; `max_results_default: 3`. No threshold changes since Apr 14. The daily autofix pipeline (added in #13, hardened in #14–#15 with Cloudflare soft-fail fallback) should be the active retrieval quality driver — worth confirming it is producing non-empty snapshots in production.
+
+## Dependency drift
+- `@upstash/redis` 1.31.1 → 1.38.0 (7 minor versions, low-risk upgrade)
+- `react` / `react-dom` 18.2.0 → 19.2.6 (major — skip)
+- All other tracked packages at wanted version
+
+## Watch list
+1. **Stale draft PRs #1 & #2** — Vercel Analytics and Speed Insights PRs have been open 61 days with no activity. Close or merge to clear the queue; they touch only `App.jsx` and `package.json`.
+2. **Autofix pipeline visibility** — Three weeks of silence after the Apr 14 pipeline merge. If no production no-case-law events have triggered a fix, confirm the daily workflow is running and its soft-fail exit is not masking real failures.
+3. **@upstash/redis drift** — Now 7 minor versions behind (1.31.1 → 1.38.0); low-risk but worth scheduling before the gap widens further.


### PR DESCRIPTION
Automated weekly health digest for the week ending 2026-05-11.

## Summary
- 0 commits landed this week; last substantive work was the retrieval-health pipeline hardening (PRs #13–#15, Apr 14)
- Two stale draft PRs (#1, #2) now 61 days old
- `@upstash/redis` is 7 minor versions behind (1.31.1 → 1.38.0)

Generated by claude-digest[bot].

https://claude.ai/code/session_01QqqZbrw2Qu5rfqDcSA6DDp

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqqZbrw2Qu5rfqDcSA6DDp)_