### PR TITLE
feat(caselaw): fix fabricated citations, expand corpus, add family law

### DIFF
--- a/api/_caseLawRetrieval.js
+++ b/api/_caseLawRetrieval.js
@@ -792,6 +792,55 @@ function detectCoreIssue(scenario) {
         "reasonable time",
       ]),
     },
+    // ── FAMILY LAW ─────────────────────────────────────────────
+    // Compound-phrase tests only (bare "custody"/"support"/"property"
+    // collide with criminal contexts). Placed LAST in orderedKeys so any
+    // criminal pattern wins first; these only classify scenarios that match
+    // no criminal pattern.
+    family_support: {
+      tests: [
+        /\b(spousal\s+support|spousal|alimony|support\s+after\s+(a\s+)?(divorce|separation)|maintenance\s+after\s+(a\s+)?(divorce|separation))\b/,
+      ],
+      primary: "family_support",
+      subIssues: new Set([
+        "spousal support",
+        "compensatory",
+        "non-compensatory",
+        "self-sufficiency",
+        "maintenance",
+        "economic disadvantage",
+        "divorce act",
+      ]),
+    },
+    family_custody: {
+      tests: [
+        /\b(child\s+custody|custody\s+battle|custody\s+dispute|custody\s+of\s+(my|our|the)\s+(child|children|kids?)|parenting\s+time|best\s+interests\s+of\s+the\s+child|access\s+to\s+(my|the)\s+(child|children)|relocate\s+with\s+(my|the)\s+(child|children)|child\s+relocation|parenting\s+(plan|order|arrangement))\b/,
+      ],
+      primary: "family_custody",
+      subIssues: new Set([
+        "custody",
+        "best interests of the child",
+        "relocation",
+        "mobility",
+        "parenting",
+        "access",
+        "material change",
+      ]),
+    },
+    family_property: {
+      tests: [
+        /\b(common[\s-]law\s+(spouse|partner|relationship)|unjust\s+enrichment|joint\s+family\s+venture|matrimonial\s+property|division\s+of\s+(family\s+)?property|constructive\s+trust)\b/,
+      ],
+      primary: "family_property",
+      subIssues: new Set([
+        "unjust enrichment",
+        "joint family venture",
+        "common law spouse",
+        "constructive trust",
+        "division of property",
+        "contributions",
+      ]),
+    },
   };
 
   const orderedKeys = [
@@ -814,6 +863,10 @@ function detectCoreIssue(scenario) {
     "uttering_threats",
     "criminal_harassment",
     "dangerous_driving",
+    // Family law last: only classifies scenarios matching no criminal pattern.
+    "family_support",
+    "family_custody",
+    "family_property",
   ];
 
   for (const key of orderedKeys) {
@@ -938,6 +991,15 @@ function detectCandidateDomains(candidate) {
     )
   )
     out.add("sentencing");
+
+  // Family law (non-criminal). Compound terms only, to avoid tagging criminal
+  // cases that merely mention "child"/"property"/"support".
+  if (
+    /\b(spousal\s+support|best\s+interests\s+of\s+the\s+child|child\s+custody|unjust\s+enrichment|joint\s+family\s+venture|common[\s-]law\s+(spouse|partner)|matrimonial|divorce\s+act|family\s+law)\b/.test(
+      haystack,
+    )
+  )
+    out.add("family_law");
 
   return out;
 }
@@ -1605,6 +1667,13 @@ function buildLocalFallbackCandidates({ scenario = "", maxResults = 3 }) {
       title: entry.title,
       summary: `${entry.ratio || ""} ${(entry.tags || []).join(" ")} ${(entry.topics || []).join(" ")}`,
     });
+
+    // Keep family-law and criminal cases in separate lanes: a family case must
+    // not leak into a criminal/general fallback (e.g. a relocation case for a
+    // "child abuse charge"), and a family issue must not surface criminal cases.
+    const issueIsFamily = String(issue.primary).startsWith("family_");
+    if (candidateDomains.has("family_law") !== issueIsFamily) continue;
+
     const compatibilityAdjustment = compatibilityAdjustmentForIssue(
       issue.primary,
       candidateDomains,

--- a/src/lib/caselaw/administrative.js
+++ b/src/lib/caselaw/administrative.js
@@ -1,6 +1,6 @@
 export const administrativeCases = [
   {
-    citation: "1999 2 SCR 817",
+    citation: "[1999] 2 SCR 817",
     title: "Baker v. Canada",
     year: 1999,
     court: "SCC",
@@ -46,25 +46,7 @@ export const administrativeCases = [
       "Defines the standard of review for an Appeal Court: questions of law are reviewed on a standard of 'correctness', while questions of fact (and mixed fact/law) can only be overturned if there was a 'palpable and overriding error'.",
   },
   {
-    citation: "1992 3 SCR 813",
-    title: "Moge v. Moge",
-    year: 1992,
-    court: "SCC",
-    topics: ["Family Law", "Spousal Support"],
-    tags: [
-      "divorce",
-      "spousal support",
-      "economic disadvantage",
-      "equitable sharing",
-      "stay-at-home parent",
-    ],
-    facts:
-      "Following a long-term marriage where the wife stayed home to raise children, the husband sought to terminate spousal support, arguing she should be self-sufficient.",
-    ratio:
-      "Revolutionized spousal support by rejecting the 'clean break' model. Established that support must recognize the long-term economic disadvantages caused by the roles assumed during marriage (e.g., stay-at-home parents).",
-  },
-  {
-    citation: "1996 3 SCR 458",
+    citation: "[1996] 3 SCR 458",
     title: "Athey v. Leonati",
     year: 1996,
     court: "SCC",

--- a/src/lib/caselaw/charter.js
+++ b/src/lib/caselaw/charter.js
@@ -1,6 +1,6 @@
 export const charterCases = [
   {
-    citation: "1986 SCC 8",
+    citation: "[1986] 1 SCR 103",
     title: "R. v. Oakes",
     year: 1986,
     court: "SCC",
@@ -12,7 +12,7 @@ export const charterCases = [
       "Establishes the 'Oakes Test' for Section 1 limitations: the government must prove a pressing and substantial objective, rational connection, minimal impairment, and proportionality between effects and objective.",
   },
   {
-    citation: "1988 SCC 30",
+    citation: "[1988] 1 SCR 30",
     title: "R. v. Morgentaler",
     year: 1988,
     court: "SCC",
@@ -47,7 +47,7 @@ export const charterCases = [
       "The absolute prohibition on assisted dying was overly broad and violated s. 7, legally establishing the right to Medical Assistance in Dying (MAID) for consenting adults.",
   },
   {
-    citation: "1990 SCC 112",
+    citation: "[1990] 3 SCR 697",
     title: "R. v. Keegstra",
     year: 1990,
     court: "SCC",
@@ -59,7 +59,7 @@ export const charterCases = [
       "Upheld hate speech laws under s. 1. While promoting hatred is 'expression' under s. 2(b), the severe harm it causes to targeted groups and democracy justifies its criminalization.",
   },
   {
-    citation: "1989 SCC 2",
+    citation: "[1989] 1 SCR 143",
     title: "Andrews v. Law Society of British Columbia",
     year: 1989,
     court: "SCC",
@@ -71,7 +71,7 @@ export const charterCases = [
       "The seminal s. 15 case. Established that 'equality' requires 'substantive' equality (protecting minority/disadvantaged groups from analogous grounds of discrimination), not identical treatment.",
   },
   {
-    citation: "1985 SCC 17",
+    citation: "[1985] 1 SCR 295",
     title: "R. v. Big M Drug Mart Ltd.",
     year: 1985,
     court: "SCC",
@@ -88,7 +88,7 @@ export const charterCases = [
       "Established that a law with a purely religious purpose violates the freedom of conscience and religion under s. 2(a). The state cannot use its coercive power to enforce religious observance.",
   },
   {
-    citation: "1988 SCC 48",
+    citation: "[1988] 2 SCR 712",
     title: "Ford v. Quebec (AG)",
     year: 1988,
     court: "SCC",
@@ -105,7 +105,7 @@ export const charterCases = [
       "While the government can protect the French language by requiring it on signs, a total ban on other languages violates the freedom of expression under s. 2(b). Commercial expression is protected by the Charter.",
   },
   {
-    citation: "1992 SCC 15",
+    citation: "[1992] 1 SCR 452",
     title: "R. v. Butler",
     year: 1992,
     court: "SCC",
@@ -122,7 +122,7 @@ export const charterCases = [
       "Redefined obscenity from 'morality-based' to 'harm-based'. Materials that are degrading or dehumanizing (particularly to women) can be restricted under s. 1 because they cause societal harm, even if they are 'expression'.",
   },
   {
-    citation: "1995 SCC 16",
+    citation: "[1995] 2 SCR 513",
     title: "Egan v. Canada",
     year: 1995,
     court: "SCC",
@@ -134,7 +134,7 @@ export const charterCases = [
       "Although the claimants lost on the specific benefit at the time, this was the first case to establish that 'sexual orientation' is an 'analogous ground' of discrimination protected under s. 15 of the Charter.",
   },
   {
-    citation: "1998 SCC 29",
+    citation: "[1998] 1 SCR 493",
     title: "Vriend v. Alberta",
     year: 1998,
     court: "SCC",

--- a/src/lib/caselaw/constitutional.js
+++ b/src/lib/caselaw/constitutional.js
@@ -12,7 +12,7 @@ export const constitutionalCases = [
       "Established the 'Living Tree' doctrine: the Constitution must be interpreted in a broad, progressive manner capable of growth, officially ruling that women are 'persons'.",
   },
   {
-    citation: "1998 SCC 25",
+    citation: "[1998] 2 SCR 217",
     title: "Reference re Secession of Quebec",
     year: 1998,
     court: "SCC",
@@ -36,7 +36,7 @@ export const constitutionalCases = [
       "The federal government cannot unilaterally alter the fundamental nature and role of the Senate; significant changes require the 7/50 amending formula with substantial provincial consent.",
   },
   {
-    citation: "1959 SCR 121",
+    citation: "[1959] SCR 121",
     title: "Roncarelli v. Duplessis",
     year: 1959,
     court: "SCC",
@@ -48,7 +48,7 @@ export const constitutionalCases = [
       "Established that no public official is above the law. Discretionary powers must be exercised in good faith and for the purposes for which they were intended, not for personal or political retribution.",
   },
   {
-    citation: "1981 1 SCR 753",
+    citation: "[1981] 1 SCR 753",
     title: "Reference re Resolution to Amend the Constitution",
     year: 1981,
     court: "SCC",

--- a/src/lib/caselaw/criminal.js
+++ b/src/lib/caselaw/criminal.js
@@ -115,7 +115,7 @@ export const criminalCases = [
 
   // ── SEXUAL ASSAULT & CONSENT ──────────────────────────────
   {
-    citation: "1999 SCC 3",
+    citation: "[1999] 1 SCR 330",
     title: "R. v. Ewanchuk",
     year: 1999,
     court: "SCC",
@@ -168,7 +168,7 @@ export const criminalCases = [
       "Evidence of a complainant's sexual history (including sex work) is strictly governed by the s. 276 rape shield provisions. Judges must explicitly instruct juries to dispel myths and stereotypes regarding Indigenous women and sex workers to ensure a fair trial.",
   },
   {
-    citation: "1991 SCC 45",
+    citation: "[1991] 2 SCR 714",
     title: "R. v. Jobidon",
     year: 1991,
     court: "SCC",
@@ -194,7 +194,7 @@ export const criminalCases = [
 
   // ── SENTENCING & GLADUE RIGHTS ────────────────────────────
   {
-    citation: "1999 SCC 20",
+    citation: "[1999] 1 SCR 688",
     title: "R. v. Gladue",
     year: 1999,
     court: "SCC",
@@ -280,7 +280,7 @@ export const criminalCases = [
 
   // ── DISCLOSURE & EVIDENCE ─────────────────────────────────
   {
-    citation: "1991 SCC 93",
+    citation: "[1991] 3 SCR 326",
     title: "R. v. Stinchcombe",
     year: 1991,
     court: "SCC",
@@ -294,7 +294,7 @@ export const criminalCases = [
 
   // ── THE OAKES TEST (CHARTER JUSTIFICATION) ────────────────
   {
-    citation: "1986 SCC 8",
+    citation: "[1986] 1 SCR 103",
     title: "R. v. Oakes",
     year: 1986,
     court: "SCC",
@@ -312,31 +312,43 @@ export const criminalCases = [
       "Establishes the 'Oakes test' for justifying Charter infringements under Section 1: The law must have a pressing and substantial objective, and the means must be proportional (rationally connected, minimally impairing, and balancing salutary/deleterious effects). The reverse onus provision failed the minimal impairment test.",
   },
   {
-    citation: "1980 SCC 77",
+    citation: "[1980] 2 SCR 331",
     title: "R. v. McLaughlin",
     year: 1980,
     court: "SCC",
-    topics: ["Robbery", "Weapons", "Criminal Code"],
-    tags: ["robbery", "s. 343", "weapon", "threat", "force"],
+    topics: ["Theft", "Criminal Code", "Computers"],
+    tags: [
+      "theft",
+      "s. 287",
+      "computer data",
+      "telecommunication facility",
+      "colour of right",
+    ],
     facts:
-      "The accused committed a robbery while using what appeared to be a firearm.",
+      "The accused used a computer, without colour of right, to obtain internal programs of the computer and information from other persons' files stored on it. He was charged with theft of a telecommunication service under s. 287(1)(b) of the Criminal Code.",
     ratio:
-      "In robbery law, objects used to intimidate victims can qualify as weapons where they are employed to threaten force and facilitate property taking.",
+      "A computer is a 'data processing facility', not a 'telecommunication facility' within s. 287(1)(b) of the Criminal Code: although intelligence was transmitted within the machine, it was not emitted to or received by outside facilities. Unauthorized computer use therefore did not constitute theft of a telecommunication, and the conviction was set aside. (Parliament later enacted the dedicated unauthorized-use-of-computer offence, s. 342.1.)",
   },
   {
-    citation: "1988 SCC 97",
+    citation: "[1988] 1 SCR 963",
     title: "R. v. Stewart",
     year: 1988,
     court: "SCC",
-    topics: ["Theft", "Property", "Criminal Code"],
-    tags: ["theft", "s. 322", "property", "dishonesty", "without consent"],
+    topics: ["Theft", "Property", "Confidential Information"],
+    tags: [
+      "theft",
+      "s. 322",
+      "confidential information",
+      "intangible property",
+      "what is property",
+    ],
     facts:
-      "The case considered the boundaries of what can constitute 'property' for theft purposes under the Criminal Code.",
+      "A man was hired to obtain the names, addresses and telephone numbers of a hotel's employees and offered a hotel security guard money for that confidential information. He was charged in connection with attempting to take it.",
     ratio:
-      "Clarifies limits of theft under s. 322 and reinforces that theft analysis focuses on dishonest taking or conversion of legally recognized property without consent.",
+      "Confidential information, by itself, is not 'property' capable of being stolen under the Criminal Code. Copying or memorizing confidential information deprives the owner of nothing tangible, so it is not theft (s. 322). The decision marks the outer limit of what can be the subject of theft.",
   },
   {
-    citation: "1990 SCC 1",
+    citation: "[1990] 1 SCR 852",
     title: "R. v. Lavallee",
     year: 1990,
     court: "SCC",
@@ -355,7 +367,7 @@ export const criminalCases = [
   },
   // ── CRIMINAL LIABILITY & FAULT ────────────────────────────
   {
-    citation: "1978 SCC 23",
+    citation: "[1978] 2 SCR 1299",
     title: "R. v. Sault Ste. Marie (City)",
     year: 1978,
     court: "SCC",
@@ -373,7 +385,7 @@ export const criminalCases = [
   },
   // ── SECTION 7 & FUNDAMENTAL JUSTICE ───────────────────────
   {
-    citation: "1985 SCC 31",
+    citation: "[1985] 2 SCR 486",
     title: "Re B.C. Motor Vehicle Act",
     year: 1985,
     court: "SCC",
@@ -398,7 +410,7 @@ export const criminalCases = [
   },
   // ── SECTION 8: WARRANTS & PRIVACY ─────────────────────────
   {
-    citation: "1984 SCC 14",
+    citation: "[1984] 2 SCR 145",
     title: "Hunter v. Southam Inc.",
     year: 1984,
     court: "SCC",
@@ -427,7 +439,7 @@ export const criminalCases = [
   },
   // ── EXCLUSION OF EVIDENCE (PRE-GRANT) ─────────────────────
   {
-    citation: "1997 SCC 48",
+    citation: "[1997] 1 SCR 607",
     title: "R. v. Stillman",
     year: 1997,
     court: "SCC",
@@ -467,5 +479,330 @@ export const criminalCases = [
       "The shooter in the Quebec City mosque shooting was sentenced to multiple consecutive 25-year blocks, effectively resulting in life without the possibility of parole for 40+ years.",
     ratio:
       "Consecutive life sentences that result in life without the realistic possibility of parole are 'cruel and unusual punishment' and violate s. 12 of the Charter. Such sentences deny the possibility of personal rehabilitation and human dignity.",
+  },
+
+  // ── SECTION 8: DIGITAL PRIVACY (INTERNET & PHONES) ────────
+  {
+    citation: "2014 SCC 43",
+    title: "R. v. Spencer",
+    year: 2014,
+    court: "SCC",
+    topics: ["Charter", "s. 8", "Search and Seizure", "Privacy"],
+    tags: [
+      "internet",
+      "ip address",
+      "isp subscriber information",
+      "anonymity",
+      "reasonable expectation of privacy",
+      "warrantless",
+    ],
+    facts:
+      "Police obtained the name and address of an internet subscriber from an ISP, without a warrant, by matching it to an IP address used to share child pornography. The accused argued this was an unreasonable search.",
+    ratio:
+      "There is a reasonable expectation of privacy in the subscriber information linked to anonymous internet activity, because it tends to reveal intimate details of the user's biographical core. Obtaining it from an ISP without prior judicial authorization or other lawful authority is a search under s. 8 and was unreasonable (though on these facts the evidence was admitted under s. 24(2)).",
+  },
+  {
+    citation: "2014 SCC 77",
+    title: "R. v. Fearon",
+    year: 2014,
+    court: "SCC",
+    topics: ["Charter", "s. 8", "Search Incident to Arrest", "Cell Phones"],
+    tags: [
+      "cell phone search",
+      "search incident to arrest",
+      "robbery",
+      "digital privacy",
+      "warrantless",
+    ],
+    facts:
+      "Following an arrest for an armed robbery, police searched the accused's cell phone without a warrant, finding a draft text message and photographs of a firearm.",
+    ratio:
+      "Police may search a cell phone incident to a lawful arrest, but only within strict limits: the search must be truly incidental to the arrest, tailored in scope to its purpose, and police must take detailed notes of what they examine. A general or exploratory rummaging through a phone's contents is not permitted.",
+  },
+
+  // ── SECTION 9: ARBITRARY DETENTION (MODERN) ───────────────
+  {
+    citation: "2019 SCC 34",
+    title: "R. v. Le",
+    year: 2019,
+    court: "SCC",
+    topics: ["Charter", "s. 9", "Arbitrary Detention", "Exclusion of Evidence"],
+    tags: [
+      "arbitrary detention",
+      "psychological detention",
+      "police entry",
+      "racial profiling",
+      "social context",
+      "s. 24(2)",
+    ],
+    facts:
+      "Three officers entered the private backyard of a townhouse where five young racialized men were talking, questioned them, and demanded identification, with no reasonable suspicion of any offence.",
+    ratio:
+      "A detention under s. 9 arose the moment police entered the backyard, and it was arbitrary because there were no reasonable grounds. The detention analysis must account for the impact of race and the broader social context of how racialized people experience police encounters. The evidence was excluded under s. 24(2).",
+  },
+
+  // ── UTTERING THREATS ──────────────────────────────────────
+  {
+    citation: "[1991] 3 SCR 72",
+    title: "R. v. McCraw",
+    year: 1991,
+    court: "SCC",
+    topics: ["Uttering Threats", "Criminal Code", "s. 264.1"],
+    tags: [
+      "uttering threats",
+      "s. 264.1",
+      "serious bodily harm",
+      "threat",
+      "objective test",
+    ],
+    facts:
+      "The accused sent letters to three women threatening to rape them and was charged with uttering threats to cause serious bodily harm under s. 264.1(1)(a).",
+    ratio:
+      "'Serious bodily harm' in s. 264.1 means any hurt or injury, physical or psychological, that interferes in a substantial way with the integrity, health or well-being of the victim. Whether words amount to a threat is decided objectively, in context, from the standpoint of a reasonable person; a threat to rape can be a threat to cause serious bodily harm.",
+  },
+
+  // ── EVIDENCE: CREDIBILITY & REASONABLE DOUBT ──────────────
+  {
+    citation: "[1991] 1 SCR 742",
+    title: "R. v. W.(D.)",
+    year: 1991,
+    court: "SCC",
+    topics: ["Evidence", "Credibility", "Reasonable Doubt"],
+    tags: [
+      "credibility",
+      "reasonable doubt",
+      "jury instruction",
+      "burden of proof",
+      "w(d)",
+    ],
+    facts:
+      "In a trial turning on whether the trier of fact believed the complainant or the accused, the defence argued the jury charge improperly framed the issue as a simple choice between the two versions.",
+    ratio:
+      "Where credibility is central, the trier of fact must apply reasonable doubt to credibility: (1) if they believe the accused, acquit; (2) if they do not believe the accused but are left in reasonable doubt by that evidence, acquit; (3) even if not left in doubt by the accused's evidence, they must acquit unless the evidence they do accept proves guilt beyond a reasonable doubt.",
+  },
+
+  // ── SECTION 12: MANDATORY MINIMUM SENTENCES ───────────────
+  {
+    citation: "2015 SCC 15",
+    title: "R. v. Nur",
+    year: 2015,
+    court: "SCC",
+    topics: ["Charter", "s. 12", "Mandatory Minimum", "Sentencing"],
+    tags: [
+      "mandatory minimum",
+      "cruel and unusual punishment",
+      "firearms",
+      "s. 95",
+      "reasonable hypothetical",
+      "grossly disproportionate",
+    ],
+    facts:
+      "The accused challenged the three-year mandatory minimum sentence for possession of a loaded prohibited firearm under s. 95 of the Criminal Code.",
+    ratio:
+      "A mandatory minimum sentence violates s. 12 if it is grossly disproportionate either for the offender before the court or in reasonably foreseeable ('reasonable hypothetical') applications. The s. 95 mandatory minimums were struck down because they could capture licensing-type conduct far less serious than the offence's core, producing grossly disproportionate sentences.",
+  },
+
+  // ── HOMICIDE: MENS REA ────────────────────────────────────
+  {
+    citation: "[1990] 2 SCR 633",
+    title: "R. v. Martineau",
+    year: 1990,
+    court: "SCC",
+    topics: ["Murder", "Mens Rea", "Charter", "s. 7"],
+    tags: [
+      "murder",
+      "subjective foresight",
+      "constructive murder",
+      "s. 230",
+      "fundamental justice",
+    ],
+    facts:
+      "The accused took part in a robbery during which his companion shot and killed the occupants. He was convicted of murder under the constructive (felony) murder provision, which did not require any foresight of death.",
+    ratio:
+      "A conviction for murder requires proof beyond a reasonable doubt of subjective foresight of death. The constructive-murder provision (then s. 213, now s. 230), which permitted a murder conviction without that foresight, violated ss. 7 and 11(d) of the Charter and was struck down.",
+  },
+  {
+    citation: "[1993] 3 SCR 3",
+    title: "R. v. Creighton",
+    year: 1993,
+    court: "SCC",
+    topics: ["Manslaughter", "Mens Rea", "Criminal Negligence"],
+    tags: [
+      "unlawful act manslaughter",
+      "objective foreseeability",
+      "bodily harm",
+      "s. 222",
+      "fault",
+    ],
+    facts:
+      "The accused injected another person with cocaine, with her consent; she died. He was charged with unlawful act manslaughter.",
+    ratio:
+      "The mens rea of unlawful act manslaughter is objective foreseeability of the risk of bodily harm that is neither trivial nor transitory, arising from a dangerous unlawful act — foreseeability of death is not required. The standard is that of a reasonable person in the circumstances of the accused.",
+  },
+
+  // ── CONFESSIONS & INTERROGATION ───────────────────────────
+  {
+    citation: "2000 SCC 38",
+    title: "R. v. Oickle",
+    year: 2000,
+    court: "SCC",
+    topics: ["Confessions", "Voluntariness", "Evidence"],
+    tags: [
+      "confessions rule",
+      "voluntariness",
+      "threats or promises",
+      "oppression",
+      "operating mind",
+      "police trickery",
+      "interrogation",
+    ],
+    facts:
+      "The accused confessed to setting a series of fires during a police interrogation that involved suggestions of leniency and psychological pressure. The admissibility of the confession was challenged.",
+    ratio:
+      "Restates the common-law confessions rule: a statement to a person in authority is inadmissible unless the Crown proves beyond a reasonable doubt that it was voluntary. Voluntariness is assessed contextually through threats or promises, oppression, the operating-mind requirement, and police trickery that would shock the community.",
+  },
+
+  // ── PARTIES TO AN OFFENCE ─────────────────────────────────
+  {
+    citation: "2010 SCC 13",
+    title: "R. v. Briscoe",
+    year: 2010,
+    court: "SCC",
+    topics: ["Parties to an Offence", "Mens Rea", "s. 21"],
+    tags: [
+      "aiding and abetting",
+      "party liability",
+      "wilful blindness",
+      "s. 21(1)",
+      "knowledge",
+      "intent",
+    ],
+    facts:
+      "The accused drove a group to a secluded location and helped during a kidnapping and murder, while claiming he did not know a killing would occur.",
+    ratio:
+      "To be liable as an aider or abettor under s. 21(1), the Crown must prove the accused did or omitted something to assist or encourage the principal, intended to do so, and knew the principal intended to commit the offence. Wilful blindness — deliberately declining to inquire once one's suspicion is aroused — can substitute for actual knowledge.",
+  },
+
+  // ── BAIL / JUDICIAL INTERIM RELEASE ───────────────────────
+  {
+    citation: "2017 SCC 27",
+    title: "R. v. Antic",
+    year: 2017,
+    court: "SCC",
+    topics: ["Bail", "Charter", "s. 11(e)", "Judicial Interim Release"],
+    tags: [
+      "bail",
+      "ladder principle",
+      "release",
+      "surety",
+      "cash bail",
+      "reasonable bail",
+      "s. 515",
+    ],
+    facts:
+      "An accused was detained when a bail review judge insisted on a cash deposit, despite other adequate forms of release being available.",
+    ratio:
+      "The right not to be denied reasonable bail without just cause (s. 11(e)) requires courts to follow the 'ladder principle' in s. 515: release on the least onerous form of bail appropriate, moving up the ladder only as necessary. Conditions must address a statutory ground for detention, not punish the accused or change behaviour; a cash deposit should not be required where other forms suffice.",
+  },
+
+  // ── DANGEROUS DRIVING ─────────────────────────────────────
+  {
+    citation: "2012 SCC 26",
+    title: "R. v. Roy",
+    year: 2012,
+    court: "SCC",
+    topics: ["Dangerous Driving", "Mens Rea", "Criminal Code"],
+    tags: [
+      "dangerous driving",
+      "marked departure",
+      "modified objective standard",
+      "criminal negligence",
+      "s. 320",
+    ],
+    facts:
+      "In poor winter visibility, the accused drove his motorhome from a stop onto a highway into the path of an oncoming tractor-trailer; the collision killed his passenger. He was convicted of dangerous driving causing death.",
+    ratio:
+      "The mens rea of dangerous driving is a marked departure from the standard of care a reasonable person would observe in the accused's circumstances (a modified objective standard). A momentary lapse or simple carelessness sufficient for civil negligence is not enough; the trier of fact must identify how the driving was a marked departure.",
+  },
+
+  // ── SECTION 8: STRIP SEARCH ───────────────────────────────
+  {
+    citation: "2001 SCC 83",
+    title: "R. v. Golden",
+    year: 2001,
+    court: "SCC",
+    topics: ["Charter", "s. 8", "Strip Search", "Search Incident to Arrest"],
+    tags: [
+      "strip search",
+      "search incident to arrest",
+      "reasonable grounds",
+      "dignity",
+      "s. 8",
+    ],
+    facts:
+      "Police strip-searched the accused in the stairwell of a restaurant after arresting him for drug trafficking, seizing cocaine.",
+    ratio:
+      "A strip search is inherently humiliating and is permissible incident to arrest only where police have reasonable and probable grounds for the strip search itself (beyond those grounding the arrest) and conduct it reasonably — generally at a police station, absent exigent circumstances. The search here breached s. 8.",
+  },
+
+  // ── SECTION 10(b): SCOPE OF RIGHT TO COUNSEL ──────────────
+  {
+    citation: "2010 SCC 35",
+    title: "R. v. Sinclair",
+    year: 2010,
+    court: "SCC",
+    topics: ["Charter", "s. 10(b)", "Right to Counsel", "Interrogation"],
+    tags: [
+      "right to counsel",
+      "interrogation",
+      "counsel present",
+      "custodial questioning",
+      "s. 10(b)",
+    ],
+    facts:
+      "After arrest for murder, the accused spoke briefly with counsel twice, then repeatedly asked to have his lawyer present during a lengthy interrogation; police continued questioning.",
+    ratio:
+      "Section 10(b) does not give a detainee the right to have counsel present throughout a custodial interrogation. The right is generally satisfied by a reasonable opportunity to consult counsel at the outset; a further consultation is required only where changed circumstances make it necessary (such as a new procedure or a significant change in jeopardy).",
+  },
+
+  // ── ENTRAPMENT ────────────────────────────────────────────
+  {
+    citation: "[1988] 2 SCR 903",
+    title: "R. v. Mack",
+    year: 1988,
+    court: "SCC",
+    topics: ["Entrapment", "Abuse of Process", "Criminal Code"],
+    tags: [
+      "entrapment",
+      "abuse of process",
+      "stay of proceedings",
+      "reasonable suspicion",
+      "police inducement",
+    ],
+    facts:
+      "Over roughly six months the accused repeatedly refused a police agent's requests to sell drugs, eventually relenting under persistent pressure and an implied threat. He raised entrapment.",
+    ratio:
+      "Entrapment occurs where (a) police provide a person the opportunity to commit an offence without reasonable suspicion that the person is already engaged in criminal activity (or without a bona fide inquiry), or (b) police go beyond providing an opportunity and actually induce the offence. Entrapment is an abuse of process; the remedy is a stay of proceedings, determined by the judge after a finding of guilt.",
+  },
+
+  // ── CONFESSIONS: MR. BIG OPERATIONS ───────────────────────
+  {
+    citation: "2014 SCC 52",
+    title: "R. v. Hart",
+    year: 2014,
+    court: "SCC",
+    topics: ["Confessions", "Evidence", "Mr. Big"],
+    tags: [
+      "mr big",
+      "undercover operation",
+      "confession",
+      "presumptively inadmissible",
+      "probative value",
+      "prejudicial effect",
+    ],
+    facts:
+      "Undercover officers running a 'Mr. Big' sting drew the accused into a fictitious criminal organization and elicited a confession to the deaths of his young daughters.",
+    ratio:
+      "Confessions obtained through 'Mr. Big' operations are presumptively inadmissible. The Crown must establish that the confession's probative value (a function of its reliability) outweighs its prejudicial effect; separately, abuse of process (such as coercion) can also require exclusion. The rule targets unreliable confessions and state abuse.",
   },
 ];

--- a/src/lib/caselaw/family.js
+++ b/src/lib/caselaw/family.js
@@ -1,0 +1,124 @@
+// Family law landmark cases (spousal support, custody / best interests,
+// common-law property / unjust enrichment). Used by the local retrieval
+// fallback and as a base for family-law landmark seeds.
+//
+// NOTE: family scenarios are not yet classified by detectCoreIssue (they fall
+// through to "general_criminal"), so these surface via token-overlap in the
+// general fallback and, for the high-frequency domains, via landmark seeds.
+
+export const familyCases = [
+  // ── SPOUSAL SUPPORT ───────────────────────────────────────
+  {
+    citation: "[1999] 1 SCR 420",
+    title: "Bracklow v. Bracklow",
+    year: 1999,
+    court: "SCC",
+    topics: ["Family Law", "Spousal Support", "Divorce Act"],
+    tags: [
+      "spousal support",
+      "non-compensatory support",
+      "needs based support",
+      "self-sufficiency",
+      "maintenance",
+    ],
+    facts:
+      "After the marriage ended, Mrs. Bracklow became disabled and unable to support herself. She sought ongoing spousal support from her former husband although she had been financially independent during much of the relationship.",
+    ratio:
+      "Spousal support rests on three conceptual bases: compensatory (for economic advantages or disadvantages arising from the marriage or its breakdown), contractual (agreements between the spouses), and non-compensatory or 'needs-based' (where one spouse cannot achieve self-sufficiency, the marriage itself can ground a residual obligation). Need alone can found an entitlement to support.",
+  },
+  {
+    citation: "[1992] 3 SCR 813",
+    title: "Moge v. Moge",
+    year: 1992,
+    court: "SCC",
+    topics: ["Family Law", "Spousal Support", "Divorce Act"],
+    tags: [
+      "spousal support",
+      "compensatory support",
+      "economic disadvantage",
+      "self-sufficiency",
+      "long marriage",
+    ],
+    facts:
+      "After a long traditional marriage in which the wife cared for the home and children, a lower court moved to terminate her spousal support on the basis that she should have become self-sufficient.",
+    ratio:
+      "Spousal support under the Divorce Act is primarily compensatory: it should recognize the economic advantages and disadvantages to each spouse arising from the marriage and its breakdown. Self-sufficiency is only one of several objectives and must not be elevated above fairly compensating a spouse for the economic consequences of the marriage.",
+  },
+
+  // ── CUSTODY / PARENTING / RELOCATION (BEST INTERESTS) ─────
+  {
+    citation: "[1996] 2 SCR 27",
+    title: "Gordon v. Goertz",
+    year: 1996,
+    court: "SCC",
+    topics: ["Family Law", "Custody", "Relocation", "Best Interests of the Child"],
+    tags: [
+      "child custody",
+      "best interests of the child",
+      "relocation",
+      "mobility",
+      "access",
+      "material change",
+    ],
+    facts:
+      "A custodial mother wished to move abroad to study, taking the child with her. The father sought to prevent the relocation and to vary custody.",
+    ratio:
+      "A parent seeking to vary a custody or access order to relocate must first establish a material change in the child's circumstances. The court then makes a fresh inquiry into the best interests of the child — the only consideration — with no legal presumption in favour of the custodial parent, although that parent's views are entitled to great respect.",
+  },
+  {
+    citation: "2022 SCC 22",
+    title: "Barendregt v. Grebliunas",
+    year: 2022,
+    court: "SCC",
+    topics: ["Family Law", "Relocation", "Best Interests of the Child"],
+    tags: [
+      "relocation",
+      "child mobility",
+      "best interests of the child",
+      "parenting",
+      "move-away",
+    ],
+    facts:
+      "Following separation, the mother sought to relocate with the children roughly ten hours away from the father, who opposed the move.",
+    ratio:
+      "Relocation decisions turn entirely on the best interests of the child, assessed through a highly fact-specific and discretionary inquiry into the child's physical, emotional and psychological safety, security and well-being. The court restated the modern relocation framework and reaffirmed the limited scope for appellate intervention in such discretionary decisions.",
+  },
+
+  // ── COMMON-LAW SPOUSES: PROPERTY & UNJUST ENRICHMENT ──────
+  {
+    citation: "2011 SCC 10",
+    title: "Kerr v. Baranow",
+    year: 2011,
+    court: "SCC",
+    topics: ["Family Law", "Unjust Enrichment", "Common-Law Spouses", "Property"],
+    tags: [
+      "common law spouse",
+      "unjust enrichment",
+      "joint family venture",
+      "division of property",
+      "constructive trust",
+    ],
+    facts:
+      "An older couple separated after a common-law relationship of more than 25 years and disputed the division of property accumulated during the relationship.",
+    ratio:
+      "Property disputes between unmarried (common-law) spouses are resolved through the law of unjust enrichment. Where the parties' relationship was a 'joint family venture' and the claimant's contributions are linked to the accumulation of wealth, the remedy may be a proportionate monetary share of that wealth rather than a fee-for-services calculation.",
+  },
+  {
+    citation: "[1980] 2 SCR 834",
+    title: "Pettkus v. Becker",
+    year: 1980,
+    court: "SCC",
+    topics: ["Family Law", "Unjust Enrichment", "Constructive Trust", "Property"],
+    tags: [
+      "unjust enrichment",
+      "constructive trust",
+      "common law spouse",
+      "property",
+      "contributions",
+    ],
+    facts:
+      "An unmarried woman contributed labour and money to her partner's farm and beekeeping business over about 19 years. On separation the property stood in his name alone.",
+    ratio:
+      "Established the modern Canadian doctrine of unjust enrichment — an enrichment, a corresponding deprivation, and the absence of any juristic reason — and recognized the remedial constructive trust as a remedy. It applied these principles to award a common-law partner a share of property to which she had contributed.",
+  },
+];

--- a/src/lib/caselaw/index.js
+++ b/src/lib/caselaw/index.js
@@ -3,6 +3,7 @@ import { charterCases } from "./charter.js";
 import { constitutionalCases } from "./constitutional.js";
 import { indigenousCases } from "./indigenous.js";
 import { administrativeCases } from "./administrative.js";
+import { familyCases } from "./family.js";
 
 /**
  * The Master Database aggregates all highly-curated Landmark Case Law sets
@@ -17,4 +18,5 @@ export const MASTER_CASE_LAW_DB = [
   ...constitutionalCases,
   ...indigenousCases,
   ...administrativeCases,
+  ...familyCases,
 ];

--- a/src/lib/caselaw/indigenous.js
+++ b/src/lib/caselaw/indigenous.js
@@ -1,6 +1,6 @@
 export const indigenousCases = [
   {
-    citation: "1990 SCC 104",
+    citation: "[1990] 1 SCR 1075",
     title: "R. v. Sparrow",
     year: 1990,
     court: "SCC",
@@ -12,7 +12,7 @@ export const indigenousCases = [
       "Established the 'Sparrow Test': the government can only limit an existing s. 35 Aboriginal right if they have a valid legislative objective and the infringement is as minimal as possible while upholding the Honour of the Crown.",
   },
   {
-    citation: "1997 SCC 302",
+    citation: "[1997] 3 SCR 1010",
     title: "Delgamuukw v. British Columbia",
     year: 1997,
     court: "SCC",
@@ -48,7 +48,7 @@ export const indigenousCases = [
       "The first case in history where the SCC formally declared Aboriginal Title over a specific territorial tract, granting the Nation exclusive control and economic benefits from the land.",
   },
   {
-    citation: "1973 SCR 313",
+    citation: "[1973] SCR 313",
     title: "Calder v. British Columbia (AG)",
     year: 1973,
     court: "SCC",
@@ -60,7 +60,7 @@ export const indigenousCases = [
       "Though the Nisga'a lost on a technicality, the case was a legal revolution: it was the first time the SCC recognized that Aboriginal title existed as a legal right rooted in historical occupation, independent of any government grant.",
   },
   {
-    citation: "1984 2 SCR 335",
+    citation: "[1984] 2 SCR 335",
     title: "Guerin v. The Queen",
     year: 1984,
     court: "SCC",
@@ -72,7 +72,7 @@ export const indigenousCases = [
       "Established that the federal government has a 'fiduciary duty' (a sui generis trust-like obligation) to act in the best interests of Indigenous groups when dealing with their surrendered lands.",
   },
   {
-    citation: "1996 2 SCR 507",
+    citation: "[1996] 2 SCR 507",
     title: "R. v. Van der Peet",
     year: 1996,
     court: "SCC",
@@ -89,7 +89,7 @@ export const indigenousCases = [
       "Created the 'Van der Peet Test': to be an Aboriginal right protected under s. 35, an activity must be an element of a practice, custom, or tradition 'integral to the distinctive culture' of the group prior to European contact.",
   },
   {
-    citation: "1999 3 SCR 451",
+    citation: "[1999] 3 SCR 456",
     title: "R. v. Marshall",
     year: 1999,
     court: "SCC",

--- a/src/lib/landmarkCases.js
+++ b/src/lib/landmarkCases.js
@@ -93,6 +93,67 @@ const LANDMARK_CASES = [
     },
   },
   {
+    citation: "R v Spencer, 2014 SCC 43",
+    title: "R v Spencer",
+    summary:
+      "Leading s. 8 case on online anonymity: police obtaining the internet subscriber information (the name and address behind an IP address) from an ISP without a warrant is a search.",
+    topics: [
+      "internet",
+      "ip address",
+      "subscriber information",
+      "online anonymity",
+      "isp",
+    ],
+    mustMatchAny: [
+      "internet",
+      "ip address",
+      "isp",
+      "subscriber",
+      "online",
+      "service provider",
+      "anonymity",
+      "spencer",
+    ],
+    structuredSummary: {
+      facts:
+        "Police identified the IP address of a computer used to access and store child pornography through a peer-to-peer file-sharing program, then obtained the matching subscriber's name and address from the internet service provider without a warrant. This led them to Mr. Spencer.",
+      held: "Obtaining the subscriber information was an unreasonable search contrary to s. 8. However, the evidence was admitted under s. 24(2) because the police had acted on a reasonable, good-faith understanding of the unsettled law, and the possession conviction was restored.",
+      ratio:
+        "Internet users have a reasonable expectation of privacy in subscriber information that links their identity to their online activity. Anonymity is an important facet of informational privacy, and revealing the subscriber behind an IP address can expose intimate details of the user's biographical core. Absent exigent circumstances or a reasonable law authorizing it, police generally require prior judicial authorization to obtain it; an ISP's voluntary disclosure does not defeat the privacy interest.",
+      significance:
+        "Spencer is the leading Canadian authority on online anonymity and the privacy of internet subscriber information, establishing that police generally need a production order or warrant to unmask the person behind an IP address.",
+    },
+  },
+  {
+    citation: "R v Fearon, 2014 SCC 77",
+    title: "R v Fearon",
+    summary:
+      "Leading case on searching a cell phone incident to arrest: permitted without a warrant only within strict limits (truly incidental, tailored in scope, with detailed notes).",
+    topics: [
+      "cell phone",
+      "cell phone search",
+      "search incident to arrest",
+      "text message",
+    ],
+    mustMatchAny: [
+      "cell phone",
+      "cellphone",
+      "smartphone",
+      "text message",
+      "search incident to arrest",
+      "fearon",
+    ],
+    structuredSummary: {
+      facts:
+        "After arresting Mr. Fearon for an armed jewellery-store robbery, police searched his cell phone (which was not password-protected) without a warrant, both at the scene and later at the station, finding a draft text message ('We did it') and photographs of a handgun.",
+      held: "On these facts the cell-phone searches did not breach s. 8; the appeal was dismissed and the conviction upheld. The Court modified the common-law power of search incident to arrest to fit cell phones.",
+      ratio:
+        "Police may search a cell phone incident to a lawful arrest without a warrant, but only if: (1) the arrest is lawful; (2) the search is truly incidental to the arrest, serving a valid law-enforcement purpose such as protecting safety, preserving evidence, or discovering evidence with prompt investigative value; (3) the nature and extent of the search are tailored to that purpose; and (4) police take detailed notes of what they examined and how. General, exploratory searches of a phone are not permitted.",
+      significance:
+        "Fearon sets the Canadian framework for warrantless cell-phone searches incident to arrest, balancing the heightened privacy interest in digital devices against legitimate law-enforcement needs.",
+    },
+  },
+  {
     citation: "R v Stinchcombe, [1991] 3 SCR 326",
     title: "R v Stinchcombe",
     summary: "Defines Crown disclosure obligations in criminal proceedings.",
@@ -126,6 +187,237 @@ const LANDMARK_CASES = [
         "The right to counsel under s. 10(b) must be implemented 'immediately' upon arrest or detention, but the short delay inherent in the s. 254(2) roadside screening device demand is a justified limitation on that right. Once a detainee is subject to a breath demand on an approved instrument, a new and distinct s. 10(b) right arises, requiring a renewed informational and implementational duty.",
       significance:
         "Woods clarifies the interplay between the roadside screening regime and s. 10(b), confirming that the roadside ASD exception constitutionally justifies brief delay in contact with counsel, while requiring fresh s. 10(b) compliance at the evidentiary breath-testing stage.",
+    },
+  },
+  {
+    citation: "R v Ewanchuk, [1999] 1 SCR 330",
+    title: "R v Ewanchuk",
+    summary:
+      "Leading sexual-assault case: there is no defence of 'implied consent'; consent is assessed subjectively from the complainant's perspective, and an honest but mistaken belief in consent must be grounded in reasonable steps.",
+    topics: [
+      "sexual",
+      "consent",
+      "sexual assault",
+      "implied consent",
+      "reasonable steps",
+    ],
+    mustMatchAny: [
+      "sexual assault",
+      "sexually assaulted",
+      "sexually",
+      "sexual",
+      "rape",
+      "raped",
+      "implied consent",
+      "molested",
+      "ewanchuk",
+    ],
+    structuredSummary: {
+      facts:
+        "A 17-year-old complainant attended the accused's trailer for a job interview. He made escalating sexual advances; each time she said 'no', and each time he briefly stopped before continuing. He was acquitted at trial on the basis of 'implied consent'.",
+      held: "Appeal allowed; a conviction for sexual assault was entered. The defence of 'implied consent' does not exist in Canadian law, and the trial judge erred in relying on it.",
+      ratio:
+        "The actus reus of sexual assault requires the absence of consent, assessed subjectively from the complainant's point of view: there is no defence of implied consent. For the mens rea, an accused relying on an honest but mistaken belief in communicated consent must have taken reasonable steps to ascertain consent; belief grounded in the complainant's silence, passivity, or ambiguous conduct is not a defence.",
+      significance:
+        "Ewanchuk is the foundational modern statement of the law of consent in sexual assault, rejecting 'implied consent' and grounding the analysis in affirmative, communicated consent and the reasonable-steps requirement.",
+    },
+  },
+  {
+    citation: "R v Khill, 2021 SCC 37",
+    title: "R v Khill",
+    summary:
+      "Leading modern self-defence case under the reformed s. 34: defensive force is judged by a multi-factor reasonableness assessment that expressly includes the accused's role in the incident.",
+    topics: [
+      "self defence",
+      "self defense",
+      "section 34",
+      "reasonable force",
+      "use of force",
+    ],
+    mustMatchAny: [
+      "self defence",
+      "self defense",
+      "defend myself",
+      "defending myself",
+      "defended myself",
+      "defend himself",
+      "stand my ground",
+      "khill",
+    ],
+    structuredSummary: {
+      facts:
+        "Mr. Khill awoke to noises and believed someone was breaking into his truck in his rural driveway at night. He took a loaded shotgun outside, confronted Jon Styres, and shot and killed him, then raised self-defence.",
+      held: "Appeal dismissed; a new trial was ordered. The trial judge erred by failing to instruct the jury to consider Mr. Khill's role in the incident as part of the reasonableness analysis under s. 34(2)(c).",
+      ratio:
+        "Self-defence under s. 34 has three elements: (1) the accused reasonably believed force was being used or threatened against them; (2) the accused acted for a defensive purpose; and (3) the act committed was reasonable in the circumstances. Reasonableness is assessed using the non-exhaustive factors in s. 34(2), and the accused's 'role in the incident' — their conduct throughout, not just at the final moment — is a mandatory consideration.",
+      significance:
+        "Khill is the leading interpretation of Canada's 2013 self-defence reforms, confirming that a person's role in creating or escalating a confrontation bears directly on whether their defensive force was reasonable.",
+    },
+  },
+  {
+    citation: "R v Antic, 2017 SCC 27",
+    title: "R v Antic",
+    summary:
+      "Leading bail case: the s. 11(e) right to reasonable bail requires courts to follow the 'ladder principle' and impose the least onerous form of release that is appropriate.",
+    topics: [
+      "bail",
+      "denied bail",
+      "bail conditions",
+      "bail hearing",
+      "surety",
+      "ladder principle",
+    ],
+    mustMatchAny: [
+      "bail",
+      "denied bail",
+      "release pending trial",
+      "surety",
+      "recognizance",
+      "bail conditions",
+      "judicial interim release",
+      "antic",
+    ],
+    structuredSummary: {
+      facts:
+        "Mr. Antic was detained when the bail review judge insisted on a cash deposit as a condition of release, even though other adequate forms of release were available under the Criminal Code.",
+      held: "The detention order was set aside. The bail judge erred by insisting on cash and failing to apply the ladder principle.",
+      ratio:
+        "Section 11(e) of the Charter guarantees the right not to be denied reasonable bail without just cause. Courts must apply the 'ladder principle' in s. 515: an accused should be released on the least onerous form of bail unless the Crown shows why a more restrictive form is necessary, and the rungs must be considered in order. Release conditions must be tied to a statutory ground for detention and must not be used to punish the accused or to change behaviour.",
+      significance:
+        "Antic is the leading modern statement of bail principles in Canada, reaffirming the presumption of release, the ladder principle, and a caution against routine or excessive conditions.",
+    },
+  },
+  {
+    citation: "R v Roy, 2012 SCC 26",
+    title: "R v Roy",
+    summary:
+      "Leading dangerous-driving case: the fault element is a 'marked departure' from the standard of a reasonable driver, assessed on a modified objective standard.",
+    topics: [
+      "dangerous driving",
+      "marked departure",
+      "dangerous operation",
+      "modified objective standard",
+      "careless driving",
+    ],
+    mustMatchAny: [
+      "dangerous driving",
+      "dangerous operation",
+      "marked departure",
+      "careless driving",
+      "driving caused",
+      "street racing",
+      "roy",
+    ],
+    structuredSummary: {
+      facts:
+        "In poor winter visibility, Mr. Roy drove his motorhome from a stop onto a highway into the path of an oncoming tractor-trailer. The collision killed his passenger, and he was convicted of dangerous driving causing death.",
+      held: "Conviction set aside and an acquittal entered: the evidence showed at most a momentary lapse, not the marked departure required for criminal fault.",
+      ratio:
+        "The mens rea of dangerous driving is a marked departure from the standard of care that a reasonable person would observe in the accused's circumstances (a modified objective standard). Conduct amounting only to civil negligence or a momentary lapse of attention is insufficient; the trier of fact must identify how and why the driving was a marked departure.",
+      significance:
+        "Roy is the leading authority on the fault element for dangerous driving, sharply distinguishing criminal driving offences from mere negligence.",
+    },
+  },
+  {
+    citation: "Gordon v Goertz, [1996] 2 SCR 27",
+    title: "Gordon v Goertz",
+    summary:
+      "Leading custody/relocation case: once a material change is shown, the court decides parenting and relocation solely on the best interests of the child.",
+    topics: [
+      "best interests of the child",
+      "child custody",
+      "custody of my child",
+      "custody battle",
+      "parenting time",
+      "relocate with my child",
+      "child relocation",
+    ],
+    mustMatchAny: [
+      "best interests of the child",
+      "child custody",
+      "custody of my child",
+      "custody of our child",
+      "custody of the children",
+      "custody battle",
+      "custody dispute",
+      "parenting time",
+      "access to my child",
+      "relocate with my child",
+      "move away with my child",
+      "gordon v goertz",
+    ],
+    structuredSummary: {
+      facts:
+        "A custodial mother wished to move abroad to study, taking the child with her. The father sought to prevent the relocation and to vary custody and access.",
+      held: "The custodial mother was permitted to relocate with the child, with the father's access adjusted; the Court used the appeal to set out the governing framework for relocation and variation.",
+      ratio:
+        "A parent seeking to vary a custody or access order to relocate must first establish a material change in the child's circumstances. The court then conducts a fresh inquiry into the best interests of the child — the only consideration — with no legal presumption in favour of the custodial parent, although that parent's views are entitled to great respect.",
+      significance:
+        "Gordon v Goertz is the foundational Canadian authority on child relocation ('mobility') and the best-interests standard for varying parenting arrangements.",
+    },
+  },
+  {
+    citation: "Moge v Moge, [1992] 3 SCR 813",
+    title: "Moge v Moge",
+    summary:
+      "Leading spousal-support case: support under the Divorce Act is primarily compensatory, recognizing the economic advantages and disadvantages arising from the marriage and its breakdown.",
+    topics: [
+      "spousal support",
+      "spousal",
+      "alimony",
+      "support after divorce",
+      "support after separation",
+    ],
+    mustMatchAny: [
+      "spousal support",
+      "spousal",
+      "alimony",
+      "support after divorce",
+      "support after separation",
+      "maintenance after divorce",
+      "moge",
+    ],
+    structuredSummary: {
+      facts:
+        "After a long traditional marriage in which the wife cared for the home and children, a lower court moved to terminate her spousal support on the basis that she should have become self-sufficient.",
+      held: "Appeal allowed; spousal support was continued. Self-sufficiency had been wrongly prioritized over fairly compensating the wife for the economic consequences of the marriage.",
+      ratio:
+        "Spousal support under the Divorce Act is primarily compensatory: it should recognize the economic advantages and disadvantages to each spouse arising from the marriage and its breakdown. Self-sufficiency is only one of several objectives and must not be elevated above fair compensation.",
+      significance:
+        "Moge transformed Canadian spousal-support law by rejecting a strict 'clean break' model in favour of a compensatory approach that accounts for the long-term economic consequences of marital roles.",
+    },
+  },
+  {
+    citation: "Kerr v Baranow, 2011 SCC 10",
+    title: "Kerr v Baranow",
+    summary:
+      "Leading case on the property rights of common-law spouses: disputes are resolved through unjust enrichment, with a 'joint family venture' analysis where the relationship pooled efforts toward shared wealth.",
+    topics: [
+      "common law spouse",
+      "common law partner",
+      "unjust enrichment",
+      "joint family venture",
+      "division of property",
+      "matrimonial property",
+    ],
+    mustMatchAny: [
+      "common law spouse",
+      "common law partner",
+      "common-law relationship",
+      "unjust enrichment",
+      "joint family venture",
+      "division of property",
+      "matrimonial property",
+      "kerr v baranow",
+    ],
+    structuredSummary: {
+      facts:
+        "An older couple separated after a common-law relationship of more than 25 years and disputed the division of property accumulated during the relationship.",
+      held: "The Court set out the unjust-enrichment and 'joint family venture' framework for common-law spouses and remitted Ms. Kerr's claim for reconsideration under it.",
+      ratio:
+        "Property disputes between unmarried (common-law) spouses are resolved through the law of unjust enrichment. Where the relationship was a 'joint family venture' and the claimant's contributions are linked to the accumulation of wealth, the remedy may be a proportionate monetary share of that wealth rather than a fee-for-services calculation.",
+      significance:
+        "Kerr v Baranow is the leading authority on the property entitlements of common-law spouses in Canada, since they fall outside the matrimonial-property statutes that apply to married couples.",
     },
   },
   {

--- a/tests/unit/caselawCorpusFallback.test.js
+++ b/tests/unit/caselawCorpusFallback.test.js
@@ -1,0 +1,327 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { findLandmarkSeeds } from "../../src/lib/landmarkCases.js";
+
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// Scenarios shaped to force the local issue fallback (no AI candidates, failing
+// fetch, no inline landmark matches) so that cases added to MASTER_CASE_LAW_DB
+// in the 2026-06 expansion are exercised. Without this, corpus additions are
+// invisible to the existing retrievalFailureSet test, which empties the DB.
+const FALLBACK_EXPECTATIONS = [
+  {
+    scenario:
+      "Police walked into my backyard and detained me even though I was just talking with friends and doing nothing wrong.",
+    expectCitation: "2019 SCC 34",
+    label: "R. v. Le (s. 9 arbitrary detention)",
+  },
+  {
+    scenario:
+      "I am facing a three year mandatory minimum sentence for possessing a loaded prohibited firearm.",
+    expectCitation: "2015 SCC 15",
+    label: "R. v. Nur (s. 12 mandatory minimum)",
+  },
+  {
+    scenario:
+      "My ex sent me text messages threatening to kill me and beat me up badly.",
+    expectCitation: "[1991] 3 SCR 72",
+    label: "R. v. McCraw (uttering threats)",
+  },
+  {
+    scenario:
+      "The judge had to decide my credibility and whether my testimony left a reasonable doubt.",
+    expectCitation: "[1991] 1 SCR 742",
+    label: "R. v. W.(D.) (credibility / reasonable doubt)",
+  },
+  {
+    scenario:
+      "I drove the getaway car but I did not know my friends were going to hurt anyone.",
+    expectCitation: "2010 SCC 13",
+    label: "R. v. Briscoe (party liability / aiding)",
+  },
+  // Note: Antic (bail) and Roy (dangerous driving) are also landmark seeds, so
+  // they surface via findLandmarkSeeds (covered in the seed describe block below)
+  // rather than the corpus fallback, and carry the seed citation format.
+];
+
+describe("case-law corpus fallback (2026-06 expansion)", () => {
+  it("surfaces newly added cases via the local issue fallback", async () => {
+    const { retrieveVerifiedCaseLaw } =
+      await import("../../api/_caseLawRetrieval.js");
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({}),
+    });
+
+    for (const { scenario, expectCitation, label } of FALLBACK_EXPECTATIONS) {
+      const { cases } = await retrieveVerifiedCaseLaw({
+        apiKey: "test-key",
+        scenario,
+        aiCaseLaw: [],
+        landmarkMatches: [],
+        maxResults: 3,
+      });
+      const citations = cases.map((c) => c.citation);
+      expect(
+        citations,
+        `${label} should surface for: "${scenario}" — got ${JSON.stringify(citations)}`,
+      ).toContain(expectCitation);
+    }
+  });
+
+  it("includes the new verified cases in MASTER_CASE_LAW_DB with their real citations", async () => {
+    const { MASTER_CASE_LAW_DB } =
+      await import("../../src/lib/caselaw/index.js");
+    const byTitle = Object.fromEntries(
+      MASTER_CASE_LAW_DB.map((c) => [c.title, c.citation]),
+    );
+
+    expect(byTitle["R. v. Spencer"]).toBe("2014 SCC 43");
+    expect(byTitle["R. v. Fearon"]).toBe("2014 SCC 77");
+    expect(byTitle["R. v. Le"]).toBe("2019 SCC 34");
+    expect(byTitle["R. v. McCraw"]).toBe("[1991] 3 SCR 72");
+    expect(byTitle["R. v. W.(D.)"]).toBe("[1991] 1 SCR 742");
+    expect(byTitle["R. v. Nur"]).toBe("2015 SCC 15");
+    expect(byTitle["R. v. Martineau"]).toBe("[1990] 2 SCR 633");
+    expect(byTitle["R. v. Creighton"]).toBe("[1993] 3 SCR 3");
+    expect(byTitle["R. v. Oickle"]).toBe("2000 SCC 38");
+    expect(byTitle["R. v. Briscoe"]).toBe("2010 SCC 13");
+    expect(byTitle["R. v. Antic"]).toBe("2017 SCC 27");
+    expect(byTitle["R. v. Roy"]).toBe("2012 SCC 26");
+    expect(byTitle["R. v. Golden"]).toBe("2001 SCC 83");
+    expect(byTitle["R. v. Sinclair"]).toBe("2010 SCC 35");
+    expect(byTitle["R. v. Mack"]).toBe("[1988] 2 SCR 903");
+    expect(byTitle["R. v. Hart"]).toBe("2014 SCC 52");
+  });
+
+  it("contains no fabricated pre-2000 'YYYY SCC N' neutral citations (integrity guard)", async () => {
+    // SCC neutral citations did not exist before 2000; any pre-2000 'SCC' cite
+    // is fabricated. This guards against re-introducing the defect fixed 2026-06.
+    const { MASTER_CASE_LAW_DB } =
+      await import("../../src/lib/caselaw/index.js");
+    const fabricated = MASTER_CASE_LAW_DB.filter((c) =>
+      /^19\d{2}\s+SCC\s+\d+$/.test(String(c.citation || "")),
+    ).map((c) => `${c.title}: ${c.citation}`);
+
+    expect(fabricated).toEqual([]);
+  });
+});
+
+describe("digital-privacy landmark seeds (2026-06 expansion)", () => {
+  const titlesFor = (scenario) =>
+    findLandmarkSeeds({ scenario, terms: [], limit: 3 }).map((s) => s.title);
+
+  it("surfaces Spencer for internet / IP / ISP subscriber scenarios", () => {
+    const titles = titlesFor(
+      "The police got my name and address from my internet service provider using my IP address without a warrant.",
+    );
+    expect(titles).toContain("R v Spencer");
+  });
+
+  it("surfaces Fearon for explicit cell-phone search scenarios", () => {
+    const titles = titlesFor(
+      "Police searched my cell phone without a warrant right after arresting me and read my text messages.",
+    );
+    expect(titles).toContain("R v Fearon");
+  });
+
+  it("does NOT fire the digital seeds on a bare 'phone' search (keeps Hunter as the s. 8 authority)", () => {
+    const titles = titlesFor(
+      "Police searched my phone without a warrant after they stopped me.",
+    );
+    expect(titles).not.toContain("R v Spencer");
+    expect(titles).not.toContain("R v Fearon");
+  });
+
+  it("does NOT over-fire the digital seeds on a generic physical search", () => {
+    const titles = titlesFor("Police searched my house without a warrant.");
+    expect(titles).not.toContain("R v Spencer");
+    expect(titles).not.toContain("R v Fearon");
+  });
+
+  it("surfaces Ewanchuk for sexual assault / consent scenarios", () => {
+    const titles = titlesFor(
+      "He sexually assaulted me at his apartment and then claimed I had consented.",
+    );
+    expect(titles).toContain("R v Ewanchuk");
+  });
+
+  it("surfaces Khill for self-defence scenarios", () => {
+    const titles = titlesFor(
+      "I shot an intruder in self defence when he came at me in my driveway at night.",
+    );
+    expect(titles).toContain("R v Khill");
+  });
+
+  it("does NOT fire the sexual-assault seed on a non-sexual consensual fight", () => {
+    const titles = titlesFor(
+      "We both agreed to a bare-knuckle fistfight and he got badly hurt.",
+    );
+    expect(titles).not.toContain("R v Ewanchuk");
+  });
+
+  it("surfaces Antic for bail scenarios", () => {
+    const titles = titlesFor(
+      "I was denied bail and the justice wants a large cash deposit before releasing me.",
+    );
+    expect(titles).toContain("R v Antic");
+  });
+
+  it("surfaces Roy for dangerous-driving scenarios", () => {
+    const titles = titlesFor(
+      "I was charged with dangerous driving causing death after a highway crash.",
+    );
+    expect(titles).toContain("R v Roy");
+  });
+
+  it("does NOT fire the dangerous-driving seed on an impaired-driving scenario", () => {
+    const titles = titlesFor(
+      "I was pulled over and charged with impaired driving over 80.",
+    );
+    expect(titles).not.toContain("R v Roy");
+  });
+});
+
+describe("family-law expansion (2026-06)", () => {
+  const FAMILY_SEEDS = ["Gordon v Goertz", "Moge v Moge", "Kerr v Baranow"];
+  const titlesFor = (scenario) =>
+    findLandmarkSeeds({ scenario, terms: [], limit: 3 }).map((s) => s.title);
+
+  it("surfaces Gordon v Goertz for custody / relocation scenarios", () => {
+    expect(
+      titlesFor("We are in a custody battle over our kids and parenting time."),
+    ).toContain("Gordon v Goertz");
+    expect(
+      titlesFor("I want to relocate with my child but my ex objects."),
+    ).toContain("Gordon v Goertz");
+  });
+
+  it("surfaces Moge for spousal-support scenarios", () => {
+    expect(
+      titlesFor("I want spousal support after my divorce from a long marriage."),
+    ).toContain("Moge v Moge");
+  });
+
+  it("surfaces Kerr v Baranow for common-law property scenarios", () => {
+    expect(
+      titlesFor(
+        "My common law partner and I are dividing property; is there unjust enrichment?",
+      ),
+    ).toContain("Kerr v Baranow");
+  });
+
+  it("does NOT over-fire family seeds on criminal scenarios that share family vocabulary", () => {
+    const criminalWithFamilyWords = [
+      "I was held in custody by the police for several hours.",
+      "I got a custodial sentence of two years in prison.",
+      "They seized my property during the search of my house.",
+      "He assaulted me and I want him charged with a crime.",
+    ];
+    for (const scenario of criminalWithFamilyWords) {
+      const titles = titlesFor(scenario);
+      for (const seed of FAMILY_SEEDS) {
+        expect(
+          titles,
+          `family seed "${seed}" must not fire for: "${scenario}"`,
+        ).not.toContain(seed);
+      }
+    }
+  });
+
+  it("includes the family cases in MASTER_CASE_LAW_DB with their real citations", async () => {
+    const { MASTER_CASE_LAW_DB } =
+      await import("../../src/lib/caselaw/index.js");
+    const byTitle = Object.fromEntries(
+      MASTER_CASE_LAW_DB.map((c) => [c.title, c.citation]),
+    );
+    expect(byTitle["Bracklow v. Bracklow"]).toBe("[1999] 1 SCR 420");
+    expect(byTitle["Moge v. Moge"]).toBe("[1992] 3 SCR 813");
+    expect(byTitle["Gordon v. Goertz"]).toBe("[1996] 2 SCR 27");
+    expect(byTitle["Barendregt v. Grebliunas"]).toBe("2022 SCC 22");
+    expect(byTitle["Kerr v. Baranow"]).toBe("2011 SCC 10");
+    expect(byTitle["Pettkus v. Becker"]).toBe("[1980] 2 SCR 834");
+  });
+
+  it("has exactly one Moge entry after moving it from administrative.js to family.js", async () => {
+    const { MASTER_CASE_LAW_DB } =
+      await import("../../src/lib/caselaw/index.js");
+    const moge = MASTER_CASE_LAW_DB.filter((c) => c.title === "Moge v. Moge");
+    expect(moge.length).toBe(1);
+  });
+
+  it("classifies family scenarios and returns family cases (not criminal) from the fallback", async () => {
+    const { retrieveVerifiedCaseLaw } =
+      await import("../../api/_caseLawRetrieval.js");
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({}),
+    });
+    const expectations = [
+      ["I want spousal support after my divorce.", "family_support"],
+      [
+        "We are in a custody battle over our kids and parenting time.",
+        "family_custody",
+      ],
+      [
+        "My common law partner and I are dividing property; is there unjust enrichment?",
+        "family_property",
+      ],
+    ];
+    for (const [scenario, expectedIssue] of expectations) {
+      const { meta } = await retrieveVerifiedCaseLaw({
+        apiKey: "test-key",
+        scenario,
+        aiCaseLaw: [],
+        landmarkMatches: [],
+        maxResults: 3,
+      });
+      expect(meta.issuePrimary, `issue for: "${scenario}"`).toBe(expectedIssue);
+    }
+  });
+
+  it("does NOT leak family corpus cases into criminal/general results (reciprocal guard)", async () => {
+    const { retrieveVerifiedCaseLaw } =
+      await import("../../api/_caseLawRetrieval.js");
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({}),
+    });
+    const FAMILY_TITLES = [
+      "Bracklow v. Bracklow",
+      "Moge v. Moge",
+      "Gordon v. Goertz",
+      "Barendregt v. Grebliunas",
+      "Kerr v. Baranow",
+      "Pettkus v. Becker",
+    ];
+    const criminalWithFamilyWords = [
+      "I am facing a child abuse charge.",
+      "They seized my property during the search of my house.",
+      "Someone stole my child's bike from our property.",
+      "My spouse assaulted me and I want him charged.",
+    ];
+    for (const scenario of criminalWithFamilyWords) {
+      const { cases } = await retrieveVerifiedCaseLaw({
+        apiKey: "test-key",
+        scenario,
+        aiCaseLaw: [],
+        landmarkMatches: [],
+        maxResults: 3,
+      });
+      const titles = cases.map((c) => c.title);
+      for (const fam of FAMILY_TITLES) {
+        expect(
+          titles,
+          `family case "${fam}" must not leak for: "${scenario}"`,
+        ).not.toContain(fam);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Case-law knowledge and relevancy overhaul for the local retrieval layer. **Every citation was verified against CanLII** before inclusion.

### Data integrity (fix)
- Replaced **24 fabricated pre-2000 `YYYY SCC N` neutral citations** in `MASTER_CASE_LAW_DB` with verified SCR citations (SCC neutral citations did not exist before 2000 — e.g. Oakes was `1986 SCC 8`, corrected to `[1986] 1 SCR 103`).
- Corrected mislabelled content: **R v McLaughlin** (real holding: computer/telecommunication theft, not robbery), **R v Marshall** page (`456`), **R v Stewart** ratio (confidential information is not stealable property).
- Normalized bracket-less SCR citations to McGill form.

### Knowledge expansion (feat)
- Added **16 verified criminal/Charter cases**: Spencer, Fearon, Le, McCraw, W(D), Nur, Martineau, Creighton, Oickle, Briscoe, Antic, Roy, Golden, Sinclair, Mack, Hart.
- Added a **family-law practice area** (`src/lib/caselaw/family.js`): spousal support, custody/relocation, common-law property (6 cases). Moved Moge out of `administrative.js` to remove a duplicate.

### Relevancy (feat)
- Added **landmark seeds** (the every-query `+8` lever), each gated against over-firing: digital privacy (Spencer, Fearon), sexual assault (Ewanchuk), self-defence (Khill), bail (Antic), dangerous driving (Roy), and family (Gordon v Goertz, Moge, Kerr v Baranow).
- Added **family issue classification** to `detectCoreIssue` (compound-phrase tests, ordered last so criminal patterns win), a `family_law` candidate domain, and a fallback **lane guard** so family scenarios return family cases and family cases don't leak into criminal results.

## Test plan
- New `tests/unit/caselawCorpusFallback.test.js`: corpus-fallback coverage, seed firing + over-fire guards, family classification + reciprocal-leak guard, and a fabricated-citation integrity guard.
- **288 unit tests pass**; production build clean; gitleaks clean; no new `console.log`; no `.env` drift.
- E2E not run: the sandbox blocks socket binding so Playwright's dev server can't start. This change is server-side data/retrieval only (no frontend, endpoint, or dependency changes), so E2E is not implicated — but it should be run locally if browser-level confidence is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)