### PR TITLE
fix(ci): unblock daily retrieval autofix PR (git add gitignored path)

### DIFF
--- a/.github/workflows/production-retrieval-autofix.yml
+++ b/.github/workflows/production-retrieval-autofix.yml
@@ -387,7 +387,10 @@ jobs:
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add api/_filterConfig.js reports/retrieval-autofix scripts/apply-retrieval-autofix.js scripts/collect-production-no-caselaw.js
+          # Only _filterConfig.js is written by --apply. reports/retrieval-autofix
+          # is gitignored (it was here before, which aborted `git add` under
+          # `set -e` and blocked the PR); the report is embedded in the PR body.
+          git add api/_filterConfig.js
           git commit -m "fix(retrieval): daily no-case-law autofix $(date +%Y-%m-%d)"
           git push origin "$BRANCH"
 


### PR DESCRIPTION
## Problem

The daily **Production Retrieval Auto-Fix** workflow has been failing on ~20 of the last 30 triggering runs. Root cause is a single line in the commit step:

```
git add api/_filterConfig.js reports/retrieval-autofix scripts/...
```

`reports/retrieval-autofix` is gitignored, so `git add` aborts under `set -euo pipefail` with exit 1 — **before `gh pr create` runs**. So on every day the failure threshold tripped, the workflow applied a deterministic filter fix, passed the corpus tests, then crashed before opening the PR. Net effect: the autofix loop has likely never opened a single PR.

The "success" runs in the history were below-threshold days (skip-summary, no repair).

## Fix

Stage only `api/_filterConfig.js` — the sole file `apply-retrieval-autofix.js --apply` writes. The collected report is already embedded in the PR body via `cat`, and report JSON/MD are uploaded as run artifacts, so nothing is lost.

## Verification

Triggered via `workflow_dispatch` with `force_run=true` from this branch to confirm the run now reaches `gh pr create` and opens a real autofix PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)