### PR TITLE
fix(retrieval): production no-case-law autofix 2026-06-18 (relevance_min_token_overlap 2→1)

### DIFF
--- a/.github/workflows/production-retrieval-autofix.yml
+++ b/.github/workflows/production-retrieval-autofix.yml
@@ -387,7 +387,10 @@ jobs:
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add api/_filterConfig.js reports/retrieval-autofix scripts/apply-retrieval-autofix.js scripts/collect-production-no-caselaw.js
+          # Only _filterConfig.js is written by --apply. reports/retrieval-autofix
+          # is gitignored (it was here before, which aborted `git add` under
+          # `set -e` and blocked the PR); the report is embedded in the PR body.
+          git add api/_filterConfig.js
           git commit -m "fix(retrieval): daily no-case-law autofix $(date +%Y-%m-%d)"
           git push origin "$BRANCH"
 

--- a/api/_filterConfig.js
+++ b/api/_filterConfig.js
@@ -194,7 +194,7 @@ export const FILTER_CONFIG = {
 
   // ── Relevance scoring defaults (override via env for calibration) ───────
   relevance_min_score: 4,
-  relevance_min_token_overlap: 2,
+  relevance_min_token_overlap: 1,
   relevance_min_concept_overlap: 1,
 };
 


### PR DESCRIPTION
**Verification PR** from the now-working daily retrieval-autofix loop (run [27734047759](https://github.com/alasdairnc/casedive/actions/runs/27734047759)).

## What the loop proposed

Derived from **10 production no-case-law failures**, the deterministic autofix lowered the relevance filter threshold:

```diff
- relevance_min_token_overlap: 2,
+ relevance_min_token_overlap: 1,
```

This loosens retrieval so queries currently returning nothing surface candidate case law.

## ⚠️ Review carefully before merging

- Lowering token-overlap to **1** is a broad loosening — it will surface more cases but raises **false-positive / low-relevance** risk. Confirm this is the right trade-off rather than a more targeted change.
- Recommend running the **`retrieval-regression-detector`** agent and `npm run improve:caselaw` / `npm run test:filter:keyed` (with a CanLII key) before merging.
- The corpus `test:retrieval-failures` passed in the run, but that corpus is small.

## Note on contents

This branch also contains the one-line workflow fix from #20 (it was created when the verifying run was dispatched from that branch). Once #20 merges to main, future daily autofix PRs will be clean single-file diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)