### PR TITLE
feat(billing): Stripe freemium subscriptions + plan-aware rate limiting

### DIFF
--- a/api/_rateLimit.js
+++ b/api/_rateLimit.js
@@ -92,14 +92,21 @@ function updateInMemoryCounter(key, bucketId) {
 }
 
 /**
- * Check whether the given IP is within the rate limit.
- * @param {string|null} ip
+ * Check whether the given identity is within the rate limit.
+ * @param {string|null} ip — identity bucket key (a client IP, or a `user:<id>`
+ *   string for authenticated requests). getClientIp() guarantees real IPs can
+ *   never collide with the `user:` namespace.
  * @param {string} [endpoint] — optional endpoint name for per-route buckets
+ * @param {{ limit?: number }} [options] — optional per-call limit override
+ *   (e.g. a higher quota for a paid plan). Falls back to the endpoint default.
  * @returns {{ allowed: boolean, remaining: number, resetAt?: string, limit: number, reason?: string }}
  */
-export async function checkRateLimit(ip, endpoint) {
+export async function checkRateLimit(ip, endpoint, options = {}) {
   const now = Date.now();
-  const maxRequests = getLimitForEndpoint(endpoint);
+  const maxRequests =
+    Number.isFinite(options.limit) && options.limit > 0
+      ? options.limit
+      : getLimitForEndpoint(endpoint);
   const bucketId = Math.floor(now / WINDOW_MS);
   const key = buildKey(endpoint, ip, bucketId);
   const resetAt = new Date((bucketId + 1) * WINDOW_MS).toISOString();

--- a/api/_stripe.js
+++ b/api/_stripe.js
@@ -1,0 +1,44 @@
+// api/_stripe.js — Stripe client + price/plan mapping (monetization Phase 3)
+//
+// Lazy, config-guarded: if STRIPE_SECRET_KEY is unset the client is null and
+// every billing endpoint degrades to a clean 503, exactly like the Supabase
+// guard in user-data.js. Nothing here runs at import time.
+
+import Stripe from "stripe";
+
+let cachedClient = null;
+
+export function isStripeConfigured() {
+  return Boolean(process.env.STRIPE_SECRET_KEY);
+}
+
+export function getStripe() {
+  if (!isStripeConfigured()) return null;
+  if (!cachedClient) {
+    cachedClient = new Stripe(process.env.STRIPE_SECRET_KEY, {
+      // Vercel functions are short-lived; cap network retries/latency.
+      maxNetworkRetries: 2,
+      timeout: 20000,
+    });
+  }
+  return cachedClient;
+}
+
+// Map a requested plan -> Stripe Price id (from env). null if unknown/unset.
+export function planToPriceId(plan) {
+  if (plan === "plus") return process.env.STRIPE_PRICE_PLUS || null;
+  if (plan === "student") return process.env.STRIPE_PRICE_STUDENT || null;
+  return null;
+}
+
+// Reverse: a Stripe Price id -> our plan name. null if it matches neither env
+// price (e.g. a legacy/removed price), so the webhook can skip it safely.
+export function priceToPlan(priceId) {
+  if (!priceId) return null;
+  if (priceId === process.env.STRIPE_PRICE_PLUS) return "plus";
+  if (priceId === process.env.STRIPE_PRICE_STUDENT) return "student";
+  return null;
+}
+
+// Plans a client is allowed to check out. Keep in sync with _subscription.js.
+export const CHECKOUT_PLANS = new Set(["plus", "student"]);

--- a/api/_subscription.js
+++ b/api/_subscription.js
@@ -1,0 +1,199 @@
+// api/_subscription.js — Plan resolution + per-plan limits (monetization Phase 1)
+//
+// Pure-ish shared module. NEVER throws and NEVER blocks a request: any failure
+// (Supabase unconfigured, bad token, DB error) degrades to the FREE plan, so
+// adding plan awareness to an endpoint can't take it down. Mirrors the auth
+// pattern in user-data.js.
+//
+// The Stripe webhook is the source of truth that writes the `subscriptions`
+// table (see supabase/migrations/0001_subscriptions.sql). This module only reads.
+
+import { createClient } from "@supabase/supabase-js";
+import { checkRateLimit, getClientIp } from "./_rateLimit.js";
+import { withRedisTimeout } from "./_redisTimeout.js";
+import { API_REDIS_TIMEOUT_MS } from "./_constants.js";
+
+export const PLAN_FREE = "free";
+export const PLAN_PLUS = "plus";
+export const PLAN_STUDENT = "student";
+
+// Statuses that entitle a user to their paid plan. Anything else (past_due,
+// canceled, inactive, unknown) falls back to free.
+const ENTITLED_STATUSES = new Set(["active", "trialing"]);
+
+// Per-plan limits. Two distinct layers:
+//   - `rateLimitPerHour` — the ABUSE ceiling enforced NOW by _rateLimit.js on
+//     every metered request. free=5 deliberately matches the historical
+//     anonymous limit, so logged-out/free behavior is unchanged.
+//   - `searchesPerDay` / `fairUseMonthly` — the PRODUCT quota (packaging). Not
+//     yet enforced; a later phase adds daily/monthly counters. `null` = fair use.
+// The UI reads `verification`/`pdfPerMonth`/`sync` for feature gating.
+export const PLAN_LIMITS = {
+  [PLAN_FREE]: {
+    label: "Free",
+    rateLimitPerHour: 5,
+    searchesPerDay: 25,
+    fairUseMonthly: null,
+    verification: "existence", // existence check only
+    pdfPerMonth: 3,
+    sync: true,
+  },
+  [PLAN_PLUS]: {
+    label: "Plus",
+    rateLimitPerHour: 100,
+    searchesPerDay: null, // fair use
+    fairUseMonthly: 500, // soft cap; throttle (not bill) past a hard multiple
+    verification: "full", // full CanLII verification + link-out
+    pdfPerMonth: null, // unlimited
+    sync: true,
+  },
+  [PLAN_STUDENT]: {
+    label: "Student",
+    rateLimitPerHour: 100,
+    searchesPerDay: null,
+    fairUseMonthly: 500,
+    verification: "full",
+    pdfPerMonth: null,
+    sync: true,
+  },
+};
+
+export function getPlanLimits(plan) {
+  return PLAN_LIMITS[plan] ?? PLAN_LIMITS[PLAN_FREE];
+}
+
+// Hourly abuse-limit for a plan. Safe for unknown plans (falls back to free).
+export function getHourlyRateLimit(plan) {
+  return getPlanLimits(plan).rateLimitPerHour;
+}
+
+function isConfigured() {
+  return Boolean(process.env.SUPABASE_URL && process.env.SUPABASE_SERVICE_KEY);
+}
+
+let cachedClient = null;
+function getClient() {
+  if (!isConfigured()) return null;
+  if (!cachedClient) {
+    cachedClient = createClient(
+      process.env.SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_KEY,
+    );
+  }
+  return cachedClient;
+}
+
+// Service-role Supabase client (bypasses RLS) for the Stripe webhook to write
+// subscription rows. Returns null when Supabase is unconfigured.
+export function getServiceClient() {
+  return getClient();
+}
+
+// Timeout-guarded Supabase reads. These run on the hot path (every
+// authenticated analyze/case-summary/export-pdf/verify call), so a hung
+// Supabase must not stall the request: on timeout withRedisTimeout rejects and
+// callers degrade to free/null exactly as they do for any other failure.
+async function timedAuthUser(supabase, token) {
+  const { data, error } = await withRedisTimeout(
+    supabase.auth.getUser(token),
+    API_REDIS_TIMEOUT_MS,
+    "Supabase auth timeout",
+  );
+  return error || !data?.user ? null : data.user;
+}
+
+async function timedPlanRow(supabase, userId) {
+  const { data, error } = await withRedisTimeout(
+    supabase
+      .from("subscriptions")
+      .select("plan, status")
+      .eq("user_id", userId)
+      .maybeSingle(),
+    API_REDIS_TIMEOUT_MS,
+    "Supabase subscriptions timeout",
+  );
+  return error ? null : (data ?? null);
+}
+
+function planFromRow(row) {
+  if (!row || !ENTITLED_STATUSES.has(row.status) || !PLAN_LIMITS[row.plan]) {
+    return PLAN_FREE;
+  }
+  return row.plan;
+}
+
+// Verify a Bearer token and return the full Supabase user (incl. email), or
+// null. Used by endpoints that need the authenticated user's identity/email
+// (e.g. creating a Stripe Checkout session). Never throws.
+export async function getAuthedUser(token) {
+  if (!token) return null;
+  const supabase = getClient();
+  if (!supabase) return null;
+  try {
+    return await timedAuthUser(supabase, token);
+  } catch {
+    return null;
+  }
+}
+
+// Extract a Bearer token from an incoming request, or null. Anonymous-safe.
+export function getBearerToken(req) {
+  const header = req?.headers?.authorization ?? "";
+  return header.startsWith("Bearer ") ? header.slice(7) : null;
+}
+
+// Resolve the effective plan for a request token.
+// Returns one of PLAN_FREE | PLAN_PLUS | PLAN_STUDENT. Falls back to FREE on any
+// failure or for anonymous requests.
+export async function resolvePlan(token) {
+  if (!token) return PLAN_FREE;
+  const supabase = getClient();
+  if (!supabase) return PLAN_FREE;
+  try {
+    const user = await timedAuthUser(supabase, token);
+    if (!user) return PLAN_FREE;
+    return planFromRow(await timedPlanRow(supabase, user.id));
+  } catch {
+    return PLAN_FREE;
+  }
+}
+
+// Convenience: resolve the authenticated user id AND plan in one call, for
+// endpoints that key rate limits on the user id (Phase 2). Returns
+// { userId, plan } with userId null for anonymous/failed auth.
+export async function resolveUserAndPlan(token) {
+  if (!token) return { userId: null, plan: PLAN_FREE };
+  const supabase = getClient();
+  if (!supabase) return { userId: null, plan: PLAN_FREE };
+  try {
+    const user = await timedAuthUser(supabase, token);
+    if (!user) return { userId: null, plan: PLAN_FREE };
+    return {
+      userId: user.id,
+      plan: planFromRow(await timedPlanRow(supabase, user.id)),
+    };
+  } catch {
+    return { userId: null, plan: PLAN_FREE };
+  }
+}
+
+// Single entry point for endpoint rate limiting. Resolves the caller's plan and
+// keys the limit bucket on the Supabase user id when authenticated (so a paid
+// user gets their own quota and never collides with strangers sharing an IP —
+// e.g. a campus or library NAT), or on the client IP when anonymous.
+//
+// The `user:` prefix can never collide with a real IP: getClientIp() validates
+// IP shape and collapses anything else to "unknown".
+//
+// Returns { result, identity, plan, userId }. `result` has the same shape as
+// checkRateLimit() so callers feed it straight into rateLimitHeaders() /
+// respondRateLimit() exactly as before.
+export async function checkRequestRateLimit(req, endpoint) {
+  const token = getBearerToken(req);
+  const { userId, plan } = await resolveUserAndPlan(token);
+  const identity = userId ? `user:${userId}` : getClientIp(req);
+  const result = await checkRateLimit(identity, endpoint, {
+    limit: getHourlyRateLimit(plan),
+  });
+  return { result, identity, plan, userId };
+}

--- a/api/analyze.js
+++ b/api/analyze.js
@@ -6,12 +6,8 @@ import { initSentry, Sentry } from "./_sentry.js";
 initSentry();
 import { buildSystemPrompt } from "../src/lib/prompts.js";
 import { MASTER_CASE_LAW_DB } from "../src/lib/caselaw/index.js";
-import {
-  checkRateLimit,
-  getClientIp,
-  rateLimitHeaders,
-  redis,
-} from "./_rateLimit.js";
+import { rateLimitHeaders, redis } from "./_rateLimit.js";
+import { checkRequestRateLimit } from "./_subscription.js";
 import { runCaseLawRetrieval } from "./_retrievalOrchestrator.js";
 import { logRetrievalMetrics } from "./_retrievalMetrics.js";
 import {
@@ -656,8 +652,9 @@ export default async function handler(req, res) {
     return;
   }
 
-  const rlResult = await checkRateLimit(getClientIp(req), "analyze");
-  logRateLimitCheck(requestId, "analyze", rlResult, getClientIp(req));
+  const { result: rlResult, identity: rlIdentity } =
+    await checkRequestRateLimit(req, "analyze");
+  logRateLimitCheck(requestId, "analyze", rlResult, rlIdentity);
   const rlHeaders = rateLimitHeaders(rlResult);
   Object.entries(rlHeaders).forEach(([k, v]) => res.setHeader(k, v));
   if (respondRateLimit(res, rlResult)) return;

--- a/api/billing-portal.js
+++ b/api/billing-portal.js
@@ -1,0 +1,96 @@
+// /api/billing-portal.js — Vercel Serverless Function
+// Returns a Stripe Customer Portal URL so an authenticated subscriber can
+// manage/cancel their plan or update payment details. Self-serve, no card
+// handling on our side.
+
+import { randomUUID } from "crypto";
+import {
+  applyStandardApiHeaders,
+  handleOptionsAndMethod,
+  respondRateLimit,
+} from "./_apiCommon.js";
+import { rateLimitHeaders } from "./_rateLimit.js";
+import {
+  checkRequestRateLimit,
+  getAuthedUser,
+  getBearerToken,
+  getServiceClient,
+} from "./_subscription.js";
+import { getStripe, isStripeConfigured } from "./_stripe.js";
+import {
+  logRequestStart,
+  logRateLimitCheck,
+  logExternalApiCall,
+  logSuccess,
+  logError,
+} from "./_logging.js";
+
+// Return target. Configured URL or production domain only — never the
+// client-controlled request Origin.
+function resolveBaseUrl() {
+  return process.env.APP_BASE_URL || "https://casedive.ca";
+}
+
+export default async function handler(req, res) {
+  const requestId = randomUUID();
+  applyStandardApiHeaders(
+    req,
+    res,
+    "POST, OPTIONS",
+    "Content-Type, Authorization",
+  );
+  if (handleOptionsAndMethod(req, res, "POST")) return;
+
+  logRequestStart(requestId, "billing-portal", req);
+
+  if (!isStripeConfigured()) {
+    return res.status(503).json({ error: "Billing is not available" });
+  }
+
+  const { result: rlResult, identity: rlIdentity } =
+    await checkRequestRateLimit(req, "billing-portal");
+  logRateLimitCheck(requestId, "billing-portal", rlResult, rlIdentity);
+  const rlHeaders = rateLimitHeaders(rlResult);
+  Object.entries(rlHeaders).forEach(([k, v]) => res.setHeader(k, v));
+  if (respondRateLimit(res, rlResult)) return;
+
+  const user = await getAuthedUser(getBearerToken(req));
+  if (!user) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  // Look up the user's Stripe customer id (written by the webhook at checkout).
+  const supabase = getServiceClient();
+  if (!supabase) {
+    return res.status(503).json({ error: "Billing is not available" });
+  }
+
+  let customerId = null;
+  try {
+    const { data, error } = await supabase
+      .from("subscriptions")
+      .select("stripe_customer_id")
+      .eq("user_id", user.id)
+      .maybeSingle();
+    if (!error) customerId = data?.stripe_customer_id ?? null;
+  } catch (err) {
+    logError(requestId, "billing-portal", err.message);
+  }
+
+  if (!customerId) {
+    return res.status(404).json({ error: "No active subscription" });
+  }
+
+  try {
+    logExternalApiCall(requestId, "billing-portal", "stripe.billingPortal");
+    const session = await getStripe().billingPortal.sessions.create({
+      customer: customerId,
+      return_url: resolveBaseUrl(),
+    });
+    logSuccess(requestId, "billing-portal");
+    return res.status(200).json({ url: session.url });
+  } catch (err) {
+    logError(requestId, "billing-portal", err.message);
+    return res.status(502).json({ error: "Failed to open billing portal" });
+  }
+}

--- a/api/case-summary.js
+++ b/api/case-summary.js
@@ -1,10 +1,6 @@
 // /api/case-summary.js — Generate structured case summary via Claude
-import {
-  redis,
-  checkRateLimit,
-  getClientIp,
-  rateLimitHeaders,
-} from "./_rateLimit.js";
+import { redis, rateLimitHeaders } from "./_rateLimit.js";
+import { checkRequestRateLimit } from "./_subscription.js";
 import { randomUUID, createHash } from "crypto";
 import {
   applyStandardApiHeaders,
@@ -153,8 +149,9 @@ export default async function handler(req, res) {
     return;
   }
 
-  const rlResult = await checkRateLimit(getClientIp(req), "case-summary");
-  logRateLimitCheck(requestId, "case-summary", rlResult, getClientIp(req));
+  const { result: rlResult, identity: rlIdentity } =
+    await checkRequestRateLimit(req, "case-summary");
+  logRateLimitCheck(requestId, "case-summary", rlResult, rlIdentity);
   const rlHeaders = rateLimitHeaders(rlResult);
   Object.entries(rlHeaders).forEach(([k, v]) => res.setHeader(k, v));
   if (respondRateLimit(res, rlResult)) return;

--- a/api/create-checkout-session.js
+++ b/api/create-checkout-session.js
@@ -1,0 +1,128 @@
+// /api/create-checkout-session.js — Vercel Serverless Function
+// Creates a Stripe Checkout (hosted) session for an authenticated user to
+// subscribe to Plus/Student. Returns the redirect URL; the client navigates to
+// it. The webhook (stripe-webhook.js) is the source of truth for plan state —
+// this endpoint never writes the subscription.
+
+import { randomUUID } from "crypto";
+import {
+  applyStandardApiHeaders,
+  handleOptionsAndMethod,
+  respondRateLimit,
+  validateJsonRequest,
+} from "./_apiCommon.js";
+import { rateLimitHeaders } from "./_rateLimit.js";
+import {
+  checkRequestRateLimit,
+  getAuthedUser,
+  getBearerToken,
+} from "./_subscription.js";
+import {
+  getStripe,
+  isStripeConfigured,
+  planToPriceId,
+  CHECKOUT_PLANS,
+} from "./_stripe.js";
+import {
+  logRequestStart,
+  logRateLimitCheck,
+  logValidationError,
+  logExternalApiCall,
+  logSuccess,
+  logError,
+} from "./_logging.js";
+
+// Redirect target. Use only a configured URL or the production domain — never
+// the request Origin, which a client controls and could point the post-checkout
+// redirect anywhere. Set APP_BASE_URL per environment (e.g. localhost in dev).
+function resolveBaseUrl() {
+  return process.env.APP_BASE_URL || "https://casedive.ca";
+}
+
+export default async function handler(req, res) {
+  const requestId = randomUUID();
+  applyStandardApiHeaders(
+    req,
+    res,
+    "POST, OPTIONS",
+    "Content-Type, Authorization",
+  );
+  if (handleOptionsAndMethod(req, res, "POST")) return;
+
+  logRequestStart(requestId, "create-checkout-session", req);
+
+  // Config guard — fail cleanly when billing isn't wired up.
+  if (!isStripeConfigured()) {
+    return res.status(503).json({ error: "Billing is not available" });
+  }
+
+  // Rate limit (keyed on the authenticated user when present).
+  const { result: rlResult, identity: rlIdentity } =
+    await checkRequestRateLimit(req, "create-checkout-session");
+  logRateLimitCheck(requestId, "create-checkout-session", rlResult, rlIdentity);
+  const rlHeaders = rateLimitHeaders(rlResult);
+  Object.entries(rlHeaders).forEach(([k, v]) => res.setHeader(k, v));
+  if (respondRateLimit(res, rlResult)) return;
+
+  // Auth — require a valid Supabase session.
+  const user = await getAuthedUser(getBearerToken(req));
+  if (!user) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  // Validate body.
+  if (
+    !validateJsonRequest(req, res, {
+      requestId,
+      endpoint: "create-checkout-session",
+      maxBytes: 1000,
+      logValidationError,
+    })
+  ) {
+    return;
+  }
+
+  const plan = req.body?.plan;
+  if (!CHECKOUT_PLANS.has(plan)) {
+    logValidationError(
+      requestId,
+      "create-checkout-session",
+      "Invalid plan",
+      "plan",
+    );
+    return res.status(400).json({ error: "Invalid plan" });
+  }
+
+  const priceId = planToPriceId(plan);
+  if (!priceId) {
+    logError(requestId, "create-checkout-session", "Price id not configured");
+    return res.status(503).json({ error: "Billing is not available" });
+  }
+
+  const baseUrl = resolveBaseUrl();
+  const stripe = getStripe();
+
+  try {
+    logExternalApiCall(requestId, "create-checkout-session", "stripe.checkout");
+    const session = await stripe.checkout.sessions.create({
+      mode: "subscription",
+      line_items: [{ price: priceId, quantity: 1 }],
+      // Bind the session to this user so the webhook can map customer -> user.
+      client_reference_id: user.id,
+      customer_email: user.email,
+      metadata: { supabase_user_id: user.id, plan },
+      subscription_data: {
+        metadata: { supabase_user_id: user.id, plan },
+      },
+      allow_promotion_codes: true,
+      success_url: `${baseUrl}/?checkout=success`,
+      cancel_url: `${baseUrl}/?checkout=cancelled`,
+    });
+
+    logSuccess(requestId, "create-checkout-session");
+    return res.status(200).json({ url: session.url });
+  } catch (err) {
+    logError(requestId, "create-checkout-session", err.message);
+    return res.status(502).json({ error: "Failed to start checkout" });
+  }
+}

--- a/api/export-pdf.js
+++ b/api/export-pdf.js
@@ -1,12 +1,8 @@
 // /api/export-pdf.js — Vercel Serverless Function
 // Generates a branded CaseDive PDF from analysis results.
 
-import {
-  redis,
-  checkRateLimit,
-  getClientIp,
-  rateLimitHeaders,
-} from "./_rateLimit.js";
+import { redis, rateLimitHeaders } from "./_rateLimit.js";
+import { checkRequestRateLimit } from "./_subscription.js";
 import PDFDocument from "pdfkit";
 import { randomUUID, createHash } from "crypto";
 import {
@@ -93,8 +89,9 @@ export default async function handler(req, res) {
     return;
   }
 
-  const rlResult = await checkRateLimit(getClientIp(req), "export-pdf");
-  logRateLimitCheck(requestId, "export-pdf", rlResult, getClientIp(req));
+  const { result: rlResult, identity: rlIdentity } =
+    await checkRequestRateLimit(req, "export-pdf");
+  logRateLimitCheck(requestId, "export-pdf", rlResult, rlIdentity);
   const rlHeaders = rateLimitHeaders(rlResult);
   Object.entries(rlHeaders).forEach(([k, v]) => res.setHeader(k, v));
   if (respondRateLimit(res, rlResult)) return;

--- a/api/stripe-webhook.js
+++ b/api/stripe-webhook.js
@@ -1,0 +1,186 @@
+// /api/stripe-webhook.js — Vercel Serverless Function
+// Stripe webhook: the SOLE writer of the `subscriptions` table and the source
+// of truth for plan/status. Verifies the Stripe signature against the RAW
+// request body, then upserts a COMPLETE row per event (no partial writes, so
+// out-of-order event delivery can't corrupt state).
+
+import { getStripe, isStripeConfigured, priceToPlan } from "./_stripe.js";
+import { getServiceClient } from "./_subscription.js";
+import { logRequestStart, logSuccess, logError } from "./_logging.js";
+import { randomUUID } from "crypto";
+
+// Vercel parses JSON bodies by default; Stripe signature verification needs the
+// UNPARSED bytes, so body parsing MUST be disabled for this route.
+export const config = { api: { bodyParser: false } };
+
+// Statuses our table's CHECK constraint permits; anything else (incomplete,
+// unpaid, paused, …) maps to "inactive" so entitlement falls back to free.
+const ALLOWED_STATUSES = new Set([
+  "active",
+  "trialing",
+  "past_due",
+  "canceled",
+]);
+
+function normalizeStatus(status) {
+  return ALLOWED_STATUSES.has(status) ? status : "inactive";
+}
+
+async function readRawBody(req) {
+  // Fast paths for runtimes that hand us the raw body directly. The stream path
+  // only works if body parsing is actually disabled (see config above); if a
+  // platform pre-parses into an object, raw bytes are unrecoverable and the
+  // signature check below will (correctly) fail — verify on a real deploy.
+  if (Buffer.isBuffer(req.body)) return req.body;
+  if (typeof req.body === "string") return Buffer.from(req.body);
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
+function customerIdOf(sub) {
+  return typeof sub.customer === "string" ? sub.customer : sub.customer?.id;
+}
+
+// Map a Stripe Subscription -> a complete `subscriptions` row.
+function subscriptionToRow(sub) {
+  const item = sub.items?.data?.[0];
+  const priceId = item?.price?.id;
+  // In Stripe's 2025+ ("basil") API — which stripe@22 targets —
+  // current_period_end lives on the subscription item, not the root. Read both.
+  const periodEndUnix = sub.current_period_end ?? item?.current_period_end;
+  return {
+    user_id: sub.metadata?.supabase_user_id ?? null,
+    stripe_customer_id: customerIdOf(sub) ?? null,
+    stripe_subscription_id: sub.id,
+    plan: priceToPlan(priceId) ?? sub.metadata?.plan ?? "free",
+    status: normalizeStatus(sub.status),
+    current_period_end: Number.isFinite(periodEndUnix)
+      ? new Date(periodEndUnix * 1000).toISOString()
+      : null,
+  };
+}
+
+// Persist a subscription. Upsert by user_id when we know it (the common path —
+// metadata carries supabase_user_id); otherwise update the existing row matched
+// by Stripe customer id. If neither resolves, skip (logged by caller).
+async function persistSubscription(supabase, sub) {
+  const row = subscriptionToRow(sub);
+  if (row.user_id) {
+    return supabase.from("subscriptions").upsert(row, { onConflict: "user_id" });
+  }
+  if (row.stripe_customer_id) {
+    const { user_id: _omit, ...rest } = row;
+    return supabase
+      .from("subscriptions")
+      .update(rest)
+      .eq("stripe_customer_id", row.stripe_customer_id);
+  }
+  return { error: new Error("no user_id or customer id on subscription") };
+}
+
+// Security headers. No CORS: this is a server-to-server endpoint with no
+// browser origin; the Stripe signature is the authentication boundary.
+function applyWebhookHeaders(res) {
+  res.setHeader("Cache-Control", "no-store");
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("X-Frame-Options", "DENY");
+  res.setHeader("Referrer-Policy", "strict-origin-when-cross-origin");
+  res.setHeader("Content-Security-Policy", "default-src 'none'");
+}
+
+export default async function handler(req, res) {
+  const requestId = randomUUID();
+  applyWebhookHeaders(res);
+
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+  if (!isStripeConfigured() || !process.env.STRIPE_WEBHOOK_SECRET) {
+    return res.status(503).json({ error: "Billing is not available" });
+  }
+
+  // Cheap pre-filter: reject anything without a signature header before we read
+  // the body, so unsigned floods can't make us buffer arbitrary payloads.
+  const sig = req.headers["stripe-signature"];
+  if (!sig) {
+    return res.status(400).json({ error: "Missing signature" });
+  }
+
+  logRequestStart(requestId, "stripe-webhook", req);
+
+  // 1) Verify signature against the raw body. Forged/unsigned -> 400.
+  let event;
+  try {
+    const raw = await readRawBody(req);
+    event = getStripe().webhooks.constructEvent(
+      raw,
+      sig,
+      process.env.STRIPE_WEBHOOK_SECRET,
+    );
+  } catch (err) {
+    logError(requestId, "stripe-webhook", `signature: ${err.message}`);
+    return res.status(400).json({ error: "Invalid signature" });
+  }
+
+  const supabase = getServiceClient();
+  if (!supabase) {
+    // Can't persist; 500 so Stripe retries once Supabase is configured.
+    logError(requestId, "stripe-webhook", "Supabase not configured");
+    return res.status(500).json({ error: "Store unavailable" });
+  }
+
+  // 2) Handle the events that change subscription state.
+  try {
+    switch (event.type) {
+      case "checkout.session.completed": {
+        const session = event.data.object;
+        const subId = session.subscription;
+        if (subId) {
+          const sub = await getStripe().subscriptions.retrieve(subId);
+          // Carry the session's user mapping in case the subscription lacks it.
+          sub.metadata = {
+            supabase_user_id:
+              sub.metadata?.supabase_user_id ??
+              session.metadata?.supabase_user_id ??
+              session.client_reference_id,
+            plan: sub.metadata?.plan ?? session.metadata?.plan,
+          };
+          const { error } = await persistSubscription(supabase, sub);
+          if (error) throw error;
+        }
+        break;
+      }
+      case "customer.subscription.created":
+      case "customer.subscription.updated": {
+        const { error } = await persistSubscription(supabase, event.data.object);
+        if (error) throw error;
+        break;
+      }
+      case "customer.subscription.deleted": {
+        const sub = event.data.object;
+        const customerId = customerIdOf(sub);
+        if (customerId) {
+          const { error } = await supabase
+            .from("subscriptions")
+            .update({ status: "canceled", plan: "free" })
+            .eq("stripe_customer_id", customerId);
+          if (error) throw error;
+        }
+        break;
+      }
+      default:
+        // Acknowledge unhandled event types so Stripe stops retrying them.
+        break;
+    }
+  } catch (err) {
+    logError(requestId, "stripe-webhook", err.message);
+    // 500 -> Stripe retries with backoff (writes are idempotent upserts).
+    return res.status(500).json({ error: "Failed to process event" });
+  }
+
+  logSuccess(requestId, "stripe-webhook");
+  return res.status(200).json({ received: true });
+}

--- a/api/verify.js
+++ b/api/verify.js
@@ -2,12 +2,8 @@
 // Batch-verifies AI-generated case citations against the CanLII API.
 // Degrades gracefully when CANLII_API_KEY is not set.
 
-import {
-  redis,
-  checkRateLimit,
-  getClientIp,
-  rateLimitHeaders,
-} from "./_rateLimit.js";
+import { redis, rateLimitHeaders } from "./_rateLimit.js";
+import { checkRequestRateLimit } from "./_subscription.js";
 import { randomUUID, createHash } from "crypto";
 import {
   applyStandardApiHeaders,
@@ -72,8 +68,9 @@ export default async function handler(req, res) {
     return;
   }
 
-  const rlResult = await checkRateLimit(getClientIp(req), "verify");
-  logRateLimitCheck(requestId, "verify", rlResult, getClientIp(req));
+  const { result: rlResult, identity: rlIdentity } =
+    await checkRequestRateLimit(req, "verify");
+  logRateLimitCheck(requestId, "verify", rlResult, rlIdentity);
   const rlHeaders = rateLimitHeaders(rlResult);
   Object.entries(rlHeaders).forEach(([k, v]) => res.setHeader(k, v));
   if (respondRateLimit(res, rlResult)) return;

--- a/docs/billing-setup-walkthrough.md
+++ b/docs/billing-setup-walkthrough.md
@@ -1,0 +1,140 @@
+# CaseDive Billing — Plain-English Setup Walkthrough
+
+Everything the code can't do for you, click by click. Do these in order.
+You'll collect **6 values** along the way and paste them into Vercel at the end:
+
+```
+SUPABASE_URL            (you may already have this)
+SUPABASE_SERVICE_KEY    (you may already have this)
+STRIPE_SECRET_KEY
+STRIPE_PRICE_PLUS
+STRIPE_PRICE_STUDENT
+STRIPE_WEBHOOK_SECRET
+APP_BASE_URL            = https://casedive.ca
+```
+
+Keep a scratch note open and paste each value as you get it.
+
+---
+
+## Step 1 — Create the database table (Supabase)
+
+This makes the table that remembers who is a paying subscriber.
+
+1. Go to <https://supabase.com> and open your CaseDive project.
+2. In the left sidebar, click **SQL Editor**.
+3. Click **+ New query**.
+4. Open the file `supabase/migrations/0001_subscriptions.sql` in your project, copy **all** of it, and paste it into the query box.
+5. Click **Run** (bottom right).
+6. You should see "Success. No rows returned." That's correct — it created the table.
+7. To confirm: left sidebar → **Table Editor** → you should now see a table called **subscriptions**.
+
+---
+
+## Step 2 — Grab your Supabase keys (probably already set)
+
+These let the server check who's logged in and save subscription status.
+
+1. Still in Supabase: left sidebar → **Project Settings** (gear icon) → **API**.
+2. Find **Project URL** — copy it → this is your `SUPABASE_URL`.
+3. Find **Project API keys** → the **`service_role`** key (NOT `anon`). Click reveal, copy it → this is your `SUPABASE_SERVICE_KEY`.
+   - ⚠️ The `service_role` key is secret. Never put it in frontend code or commit it. You'll only paste it into Vercel.
+
+> If CaseDive login/sync already works in production, these two are likely already in Vercel — you can skip pasting them again, but having them noted doesn't hurt.
+
+---
+
+## Step 3 — Create your Stripe products and prices
+
+This defines the $9 and $5 plans.
+
+1. Go to <https://dashboard.stripe.com> and sign up / log in.
+2. **Top-right: make sure the toggle says "Test mode"** (it should be ON / orange). Everything now is fake money — safe to experiment.
+3. Left sidebar → **Product catalog** (or **Products**) → click **+ Add product**.
+4. Fill in:
+   - **Name:** `CaseDive Plus`
+   - **Pricing model:** Recurring
+   - **Price:** `9.00`, Currency: **CAD**, Billing period: **Monthly**
+5. Click **Add product** (or **Save**).
+6. On the product page you'll see the price listed. Click it, and find the **Price ID** — it looks like `price_1AbC...`. Copy it → this is `STRIPE_PRICE_PLUS`.
+7. Now make the student price. Easiest: on the same product page click **+ Add another price**, set `5.00` CAD Monthly, save, and copy that new **Price ID** → this is `STRIPE_PRICE_STUDENT`.
+   - (Or create a separate product called "CaseDive Student" the same way.)
+
+> Tip: a "Product" is the thing you sell; a "Price" is a specific amount for it. The code needs the **Price** IDs, not the product IDs.
+
+---
+
+## Step 4 — Get your Stripe secret key
+
+This lets the server talk to Stripe.
+
+1. Stripe dashboard (still Test mode) → left sidebar → **Developers** → **API keys**.
+2. Find **Secret key**. Click **Reveal test key**.
+3. Copy it — it starts with `sk_test_...` → this is `STRIPE_SECRET_KEY`.
+   - ⚠️ Secret. Only paste it into Vercel, never into the website code.
+
+---
+
+## Step 5 — Put the values into Vercel and deploy
+
+1. Go to <https://vercel.com>, open the **CaseDive** project.
+2. Top menu → **Settings** → left sidebar → **Environment Variables**.
+3. For each value below, type the **Name** exactly, paste the **Value**, leave environments as **Production, Preview, Development** (all checked), and click **Save**:
+   - `STRIPE_SECRET_KEY` = your `sk_test_...`
+   - `STRIPE_PRICE_PLUS` = your `price_...` (Plus)
+   - `STRIPE_PRICE_STUDENT` = your `price_...` (Student)
+   - `APP_BASE_URL` = `https://casedive.ca`
+   - `SUPABASE_URL` and `SUPABASE_SERVICE_KEY` — only if they're not already listed.
+   - (You'll add `STRIPE_WEBHOOK_SECRET` in Step 6 — skip it for now.)
+4. **Redeploy so the new variables take effect:** top menu → **Deployments** → the latest one → the **⋯** menu → **Redeploy**.
+
+---
+
+## Step 6 — Connect the Stripe webhook
+
+A "webhook" is Stripe phoning your server to say "this person just paid." Without it, payments succeed but your app never learns about them.
+
+1. Stripe dashboard (Test mode) → **Developers** → **Webhooks** → **+ Add endpoint** (or **Add destination**).
+2. **Endpoint URL:** `https://casedive.ca/api/stripe-webhook`
+3. **Select events to send** → click **Select events** and tick these four:
+   - `checkout.session.completed`
+   - `customer.subscription.created`
+   - `customer.subscription.updated`
+   - `customer.subscription.deleted`
+4. Click **Add endpoint**.
+5. On the new endpoint's page, find **Signing secret** → click **Reveal**. It starts with `whsec_...`. Copy it → this is `STRIPE_WEBHOOK_SECRET`.
+6. Back in **Vercel → Settings → Environment Variables**, add `STRIPE_WEBHOOK_SECRET` = that `whsec_...` value, Save.
+7. **Redeploy again** (Deployments → latest → ⋯ → Redeploy) so the secret is live.
+
+---
+
+## Step 7 — Test that the webhook actually works (important)
+
+This is the one thing that must be checked on the live site.
+
+1. Stripe dashboard → **Developers** → **Webhooks** → click your `casedive.ca/api/stripe-webhook` endpoint.
+2. Click **Send test event** (or **Send test webhook**).
+3. Choose event type **`checkout.session.completed`** → **Send test event**.
+4. Look at the response Stripe shows for that delivery:
+   - **`200`** = working. 🎉
+   - **`500`** = the security check passed but the fake test data had no real subscription to look up. **This is fine for a test event** — it means the important part (reading the real message) works.
+   - **`400` "Invalid signature"** = ❌ problem. The server couldn't read the raw message (a known hosting quirk). **Tell Claude "the webhook returns 400"** and it'll switch the approach.
+5. So: **anything except 400 means the webhook plumbing is good.**
+
+> Real end-to-end (with a real test card `4242 4242 4242 4242`) becomes possible once the Upgrade button exists in the app — that's the next coding step (Phase 4).
+
+---
+
+## Step 8 — Before charging REAL money (don't skip)
+
+Everything above is fake/test money. Before flipping to live:
+
+1. **Add legal pages:** Terms of Service, Privacy Policy, and a visible disclaimer: *"CaseDive provides legal information, not legal advice. Verify all citations before relying on them."*
+2. **Check CanLII's API license** allows a paid product (email them if unsure). If it doesn't, the paid feature switches to just linking out to CanLII instead of showing their content.
+3. **Go live:** in Stripe, flip the toggle to **Live mode**, then redo Steps 3, 4, and 6 with the **live** keys/prices (live keys start with `sk_live_` / `whsec_`), and update those values in Vercel.
+
+---
+
+## If you get stuck
+
+Tell Claude which step number and what you see on screen. The most likely snag is Step 7 returning 400 — that's a known item with a ready fix.

--- a/docs/monetization-plan.md
+++ b/docs/monetization-plan.md
@@ -1,0 +1,192 @@
+# CaseDive Monetization Plan
+
+_Status: draft — approved direction, build in progress. Last updated 2026-06-19._
+
+## Decisions locked (with the user)
+
+| Decision | Choice |
+| --- | --- |
+| Primary buyer | **B2C — self-represented litigants + students** |
+| Model | **Freemium subscription** (free tier → paid "Plus") |
+| Processor | **Stripe** (Checkout + Customer Portal), Canada-only at launch |
+| Scope | Write plan, then build Phase-1 foundation |
+
+## TL;DR
+
+Sell **trust, not volume.** Inference is on `claude-haiku-4-5` and costs roughly **$0.01–0.02 per search**, so gating raw search count starves the funnel for no real cost saving. The paid hook is **citation verification against CanLII** (we already have `api/verify.js`) plus pro workflow features. Verification is simultaneously the premium feature and the liability shield for the highest-consumer-harm audience we're selling to.
+
+Launch is **Canada-only, under the GST/HST small-supplier threshold**, so we charge no sales tax at v1. Plain Stripe is correct; no Merchant-of-Record needed yet.
+
+Real money is **gated on a legal layer** (Terms, "legal information, not legal advice" disclaimer, verification live). Plumbing can be built and tested now in Stripe test mode.
+
+---
+
+## 1. Positioning & the liability reframe
+
+Self-represented litigants are the **lowest professional/UPL liability** but the **highest consumer-harm** audience: they cannot tell a real citation from a hallucinated one, and they file what they find in real court. Canadian courts have already sanctioned a party for submitting fabricated AI-generated case citations (BC Supreme Court, 2024 — _verify exact citation (likely Zhang v Chen, 2024 BCSC 285) against CanLII before publishing this doc_). Our own corpus history (24 fabricated pre-2000 SCC cites, fixed 2026-06-16) means accuracy is the trust battleground.
+
+**Consequence for packaging:** the paid tier is built around **"every citation checked against CanLII, with a link to the real decision."** That:
+
+- gives a concrete, demonstrable reason to pay (not just "more searches"),
+- doubles as the liability shield (we surface verification state instead of asserting correctness),
+- keeps the free funnel wide, which matches the near-zero marginal inference cost.
+
+Brand promise: **CaseDive helps you find real, verifiable Canadian law — and proves it.**
+
+---
+
+## 2. Pricing & packaging
+
+Two tiers, plus a student discount on the paid tier. Prices in **CAD**.
+
+| Capability | Free (anon) | Free (account) | **Plus — $9/mo** ($90/yr) |
+| --- | --- | --- | --- |
+| Searches | 5 / hour (current IP limit) | ~25 / day | Fair-use (soft 500/mo) |
+| Results per query | Standard | Standard | Standard + extended |
+| **CanLII citation verification** | — | Existence check only | **Full: every cite verified + link-out** |
+| Cloud sync (bookmarks/history/scenarios) | — | ✅ | ✅ |
+| PDF memo export | — | 3 / month | Unlimited |
+| Search history retention | Session | 100 items | Full |
+| Priority during high load | — | — | ✅ |
+
+- **Student plan:** Plus at **$5/mo**, gated on `.edu`/`.ca` student email or simple manual verification. (You are the first user — dogfood this.)
+- **Annual:** ~2 months free ($90/yr) to pull cash forward and cut churn.
+- **No free trial of Plus at launch** — the generous free account tier *is* the trial. Revisit once conversion data exists.
+
+Anchoring: consumer SaaS sits at ~$9.99; budget-constrained self-reps and students need it lower than pro legal tools (which are $50–200+/mo). $9 / $5 student is deliberately accessible.
+
+---
+
+## 3. Unit economics
+
+Per-search cost on `claude-haiku-4-5` (~$1/M input, ~$5/M output), ~5K input + 1.8K output tokens: **≈ $0.014/search**. CanLII verification calls are cached 7 days (`_canliiCache.js`) and the CanLII API itself is free-tier. So:
+
+- A Plus user doing 500 searches/mo costs **≈ $7** in inference worst-case — already margin-positive at $9, and most users do far fewer.
+- The **fair-use soft cap (500/mo)** + a hard cap (e.g. 2,000/mo) caps the tail-risk user. Above the hard cap → throttle, not surprise-bill (we're not metered).
+- Stripe fee: 2.9% + $0.30 ≈ **$0.56 on a $9 charge**. Net ≈ $8.44/mo/Plus user.
+
+Conclusion: margins are healthy; the only real cost lever is the abusive tail, handled by the cap, not by squeezing normal users.
+
+---
+
+## 4. Technical architecture
+
+Reuses the existing Supabase + serverless patterns. Nothing about auth changes — we extend it.
+
+### 4.1 The mechanism change that's easy to miss: rate-limit keying
+
+`api/_rateLimit.js` currently keys on `getClientIp()`. Freemium **cannot** sit on IP:
+
+- students share IPs (campus / library / cafe) → a paying user collides with strangers' quota;
+- at limit-check time we don't know *who* the user is, so we can't grant the higher quota.
+
+**Fix:** authenticated requests key on the **Supabase user id**; anonymous requests stay IP-keyed. That means `analyze.js`, `case-summary.js`, `export-pdf.js`, and `verify.js` must accept an **optional** `Authorization: Bearer` token and verify it the way `user-data.js` already does, then choose the quota from the user's plan. This is a real mechanism change, not a bigger number.
+
+### 4.2 Stripe (Vercel) — the footguns
+
+- **Webhook handler must use the RAW request body** — `stripe.webhooks.constructEvent` needs the unparsed buffer for signature verification. Our API uses `validateJsonRequest` (which parses); the webhook endpoint must **disable body parsing** (`export const config = { api: { bodyParser: false } }`) and read the raw stream. This is the #1 thing that silently breaks Stripe webhooks.
+- **Gating is enforced server-side, always.** The client can hide the upgrade UI; the quota/feature unlock is checked in the endpoint, never trusted from the client.
+- **Use Stripe Checkout (hosted) + Customer Portal** — free PCI compliance, free self-serve cancellation/upgrade. Do **not** build card forms.
+- **Webhook is the source of truth** for subscription state. It maps Stripe `customer_id` ↔ Supabase `user.id` and writes plan status to Supabase.
+
+### 4.3 New pieces
+
+- **DB:** `subscriptions` table (see `supabase/migrations/`): `user_id`, `stripe_customer_id`, `stripe_subscription_id`, `plan` (`free`/`plus`/`student`), `status`, `current_period_end`. RLS so a user reads only their own row; the service key (webhook) writes.
+- **`api/_subscription.js`** (shared module): plan/quota config + `resolveUserPlan(token)` → `{ plan, quota }`; pure, cacheable.
+- **`api/create-checkout-session.js`** (new endpoint): auth required → creates a Stripe Checkout session for Plus/student, returns the URL.
+- **`api/stripe-webhook.js`** (new endpoint): raw body, signature-verified, upserts `subscriptions` on `checkout.session.completed`, `customer.subscription.updated/deleted`.
+- **`api/billing-portal.js`** (new endpoint, optional v1.1): returns a Customer Portal URL for managing/cancelling.
+- **Frontend:** an `UpgradeModal` + a pricing section (no router — it's a component/modal in `App.jsx`, matching `AuthModal.jsx`). A `usePlan()` hook reads the user's plan for UI gating.
+
+New endpoints follow the `new-api-endpoint` conventions (rate limit, input validation, security headers) and pass `api-invariant-reviewer` + an `advisor()` gate before business logic, per CLAUDE.md.
+
+---
+
+## 5. Canadian tax posture
+
+Canada's **GST/HST small-supplier threshold is ~$30,000 CAD** of taxable revenue over four rolling quarters (_verify current figure with CRA before launch_). Below it, we are **not required to register for or charge GST/HST.** At launch we will be far below it, so **v1 charges no sales tax** and Stripe's plain integration is sufficient.
+
+Defer, with a trigger: revisit registration as we approach the threshold. If we later expand beyond Canada (US/EU digital-goods tax becomes a real burden), the clean exit is a **Merchant-of-Record** (Paddle / Lemon Squeezy) that handles global tax remittance — but adopting one now would add cost and complexity for a problem we don't have.
+
+---
+
+## 6. Legal & compliance — the launch gate
+
+**Do not flip to live payments until all of these exist.** Building/test-mode plumbing is fine before; taking real money from self-reps without these is not.
+
+- [ ] **Terms of Service** + **Privacy Policy** (we store accounts, history, payment-linked data).
+- [ ] **Prominent disclaimer**: "CaseDive provides legal *information*, not legal *advice*. Verify all citations before relying on them." Shown at signup and on results.
+- [ ] **Verification feature live** (the paid promise must actually work end-to-end before it's sold).
+- [ ] **Refund policy** (Stripe makes refunds trivial; state a clear policy, e.g. 7-day no-questions).
+- [ ] **CanLII commercial-use license — OPEN BLOCKER.** CanLII's API terms restrict commercial redistribution of their content. Our paid value leans on CanLII verification. **Confirm the license permits a paid commercial product** before building the verification-as-premium path. Mitigation if restricted: verification surfaces only an *existence check + link-out* to CanLII (no content redistribution), which is a far lighter posture — but this must be confirmed, not assumed. _This can block the business model; resolve early._
+
+---
+
+## 7. Phased rollout
+
+- **Phase 0 — Legal (blocks launch, not build):** ToS, Privacy, disclaimer copy, CanLII license confirmation.
+- **Phase 1 — Foundation ✅ DONE:** `subscriptions` migration + `api/_subscription.js` plan/quota module. Additive, breaks nothing, testable without Stripe.
+- **Phase 2 — Rate-limit + gating ✅ DONE:** user-id keying via `checkRequestRateLimit` (auth requests key on `user:<id>`, anon stay IP-keyed); `_rateLimit.js` gained an optional per-call `limit`; `analyze`/`case-summary`/`export-pdf`/`verify` now plan-aware. Free hourly limit pinned to 5 (= legacy anon), paid = 100. 11 regression tests; full suite 278/278.
+- **Phase 3 — Stripe ✅ BUILT (test-mode, awaiting owner setup):** `stripe@^22` added; `api/_stripe.js`, `api/create-checkout-session.js`, `api/billing-portal.js`, `api/stripe-webhook.js` (raw body + signature verify + complete-row upserts). Degrades to 503 until env vars exist. 8 regression tests; full suite 286/286; build clean. Needs the owner runbook below before it can run.
+
+---
+
+## Owner setup runbook — do these IN ORDER
+
+Steps only Alasdair can do (accounts, keys, env vars). Code is already done.
+
+### A. Database (Supabase)
+1. Open the Supabase project → **SQL Editor** → paste and run `supabase/migrations/0001_subscriptions.sql`. Confirm the `subscriptions` table exists with RLS on.
+2. Confirm Vercel has `SUPABASE_URL` and `SUPABASE_SERVICE_KEY` (already required for account sync — likely present).
+
+### B. Stripe products (TEST mode — keep the toggle on "Test")
+3. Create/sign in to Stripe. Stay in **Test mode**.
+4. **Product catalog → Add product**: "CaseDive Plus", recurring price **$9.00 CAD / month** → copy the **Price ID** (`price_…`) → this is `STRIPE_PRICE_PLUS`.
+5. Add a second price (same or new product): "CaseDive Student" **$5.00 CAD / month** → Price ID → `STRIPE_PRICE_STUDENT`.
+6. **Developers → API keys** → copy the **test Secret key** (`sk_test_…`) → `STRIPE_SECRET_KEY`.
+
+### C. Env vars + deploy
+7. In Vercel → Project → Settings → Environment Variables, add: `STRIPE_SECRET_KEY`, `STRIPE_PRICE_PLUS`, `STRIPE_PRICE_STUDENT`, `APP_BASE_URL` (e.g. `https://casedive.ca`). (Add `STRIPE_WEBHOOK_SECRET` in step 9.)
+8. Deploy, so `/api/stripe-webhook` is live at a public URL.
+9. **Developers → Webhooks → Add endpoint** = `https://casedive.ca/api/stripe-webhook`. Select events: `checkout.session.completed`, `customer.subscription.created`, `customer.subscription.updated`, `customer.subscription.deleted`. Save → copy the **Signing secret** (`whsec_…`) → add as `STRIPE_WEBHOOK_SECRET` in Vercel → redeploy.
+
+### D. Webhook round-trip test — REQUIRED GATE (not optional)
+10. `brew install stripe/stripe-cli/stripe` → `stripe login` → `stripe listen --forward-to localhost:3000/api/stripe-webhook` (prints a local `whsec_` to use in `.env`). Start `npm run dev:api`, then `stripe trigger checkout.session.completed`.
+    - **Confirm the webhook returns `200` and a row appears in `subscriptions`.**
+    - **A `400` on a legitimate signed event means Vercel pre-parsed the body** (the `bodyParser:false` raw-body assumption failed) — the webhook is NOT working and no subscription will ever activate. Do not consider the webhook done until a signed event round-trips to a row. This is the one part of Phase 3 that cannot be verified by unit tests.
+
+### E. Launch gate — before flipping to LIVE keys
+11. Publish **Terms of Service**, **Privacy Policy**, and the **"legal information, not legal advice" disclaimer**.
+12. **Confirm CanLII's commercial-use license** permits the paid product (or restrict the paid feature to existence-check + link-out).
+13. Verification feature live. Then switch Stripe to **live mode**, repeat steps 4–9 with live keys/prices, and soft-launch.
+
+> Env var reference (add to `.env` locally / Vercel; the repo's `.env.example` can't be edited by the assistant — copy these manually):
+> `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRICE_PLUS`, `STRIPE_PRICE_STUDENT`, `APP_BASE_URL`, plus existing `SUPABASE_URL`, `SUPABASE_SERVICE_KEY`.
+
+### Still on the code side (assistant) — Phase 4
+- `usePlan()` hook + an Upgrade button/modal calling `create-checkout-session`, a "Manage billing" link calling `billing-portal`, and feature gating (verification depth, PDF limits). Buildable now without keys; the endpoints 503 cleanly until you finish A–C.
+- **Phase 4 — Frontend:** `UpgradeModal`, pricing section, `usePlan()` gating, student verification.
+- **Phase 5 — Launch:** Phase 0 complete → flip Stripe to live keys → soft launch to a small cohort → monitor.
+
+---
+
+## 8. Metrics / KPIs
+
+- **Activation:** % of new accounts that run ≥1 verified search.
+- **Free→Plus conversion** (target 2–5% for consumer freemium).
+- **MRR / ARPU**, **churn** (monthly), **annual mix**.
+- **Margin guard:** searches/user distribution vs the fair-use cap.
+- **Trust signal:** verification pass-rate on surfaced citations (also a product-quality metric).
+
+---
+
+## 9. Open risks
+
+| Risk | Mitigation |
+| --- | --- |
+| CanLII commercial license restricts use | Confirm early; fall back to existence-check + link-out only |
+| Hallucinated cites erode trust / legal exposure | Verification as the core paid feature + clear disclaimer |
+| Low willingness-to-pay among self-reps | Keep free tier generous; price low ($9 / $5 student); annual nudge |
+| Abusive heavy users | Fair-use soft cap + hard throttle, not surprise billing |
+| Stripe webhook signature failures | Raw-body handler, verified in test mode before live |
+| Crossing GST/HST threshold unnoticed | Track revenue; register when approaching ~$30k CAD |

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "@vercel/analytics": "^2.0.1",
         "pdfkit": "^0.18.0",
         "react": "18.2.0",
-        "react-dom": "18.2.0"
+        "react-dom": "18.2.0",
+        "stripe": "^22.2.2"
       },
       "devDependencies": {
         "@playwright/test": "^1.60.0",
@@ -6741,6 +6742,23 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "22.2.2",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.2.2.tgz",
+      "integrity": "sha512-lRXLiarjW/I2QVa6QuFfz1Ma7Dc2yBQ7vlYH6NEmp5htMJNQGfiWExmOv0McfqY5wMCGV8DLuCvsyVRIPJlUUQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "@vercel/analytics": "^2.0.1",
     "pdfkit": "^0.18.0",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "stripe": "^22.2.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",

--- a/scripts/stripe-setup.mjs
+++ b/scripts/stripe-setup.mjs
@@ -1,0 +1,104 @@
+// scripts/stripe-setup.mjs
+// One-time (re-runnable) Stripe setup for CaseDive billing.
+// Creates/reuses the Plus + Student products & prices and the webhook endpoint,
+// then prints the env values to paste into Vercel.
+//
+// Usage:
+//   STRIPE_SECRET_KEY=sk_test_xxx node scripts/stripe-setup.mjs
+//   STRIPE_SECRET_KEY=sk_live_xxx APP_BASE_URL=https://casedive.ca node scripts/stripe-setup.mjs
+//
+// Safe to re-run: products/prices are matched by name + amount and reused; the
+// webhook for the same URL is deleted and recreated so a fresh signing secret
+// is printed (the secret is only returned by Stripe on create).
+
+import Stripe from "stripe";
+
+const key = process.env.STRIPE_SECRET_KEY;
+if (!key) {
+  console.error("Missing STRIPE_SECRET_KEY env var.");
+  process.exit(1);
+}
+const live = key.startsWith("sk_live_");
+const stripe = new Stripe(key);
+
+const APP_BASE_URL = process.env.APP_BASE_URL || "https://casedive.ca";
+const WEBHOOK_URL = `${APP_BASE_URL}/api/stripe-webhook`;
+const EVENTS = [
+  "checkout.session.completed",
+  "customer.subscription.created",
+  "customer.subscription.updated",
+  "customer.subscription.deleted",
+];
+
+const PLANS = [
+  { key: "plus", name: "CaseDive Plus", amount: 900, currency: "cad" },
+  { key: "student", name: "CaseDive Student", amount: 500, currency: "cad" },
+];
+
+async function findProductByName(name) {
+  const list = await stripe.products.list({ limit: 100, active: true });
+  return list.data.find((p) => p.name === name) || null;
+}
+
+async function ensureProductPrice({ name, amount, currency }) {
+  let product = await findProductByName(name);
+  if (!product) product = await stripe.products.create({ name });
+
+  const prices = await stripe.prices.list({
+    product: product.id,
+    active: true,
+    limit: 100,
+  });
+  let price = prices.data.find(
+    (p) =>
+      p.unit_amount === amount &&
+      p.currency === currency &&
+      p.recurring?.interval === "month",
+  );
+  if (!price) {
+    price = await stripe.prices.create({
+      product: product.id,
+      unit_amount: amount,
+      currency,
+      recurring: { interval: "month" },
+    });
+  }
+  return price.id;
+}
+
+async function recreateWebhook() {
+  const existing = await stripe.webhookEndpoints.list({ limit: 100 });
+  for (const ep of existing.data) {
+    if (ep.url === WEBHOOK_URL) await stripe.webhookEndpoints.del(ep.id);
+  }
+  const ep = await stripe.webhookEndpoints.create({
+    url: WEBHOOK_URL,
+    enabled_events: EVENTS,
+  });
+  return ep.secret; // whsec_... — only returned on create
+}
+
+async function main() {
+  console.log(`Mode: ${live ? "LIVE" : "TEST"}`);
+  const out = {};
+  for (const plan of PLANS) {
+    out[plan.key] = await ensureProductPrice(plan);
+    console.log(`✓ ${plan.name}: ${out[plan.key]}`);
+  }
+  const whsec = await recreateWebhook();
+  console.log(`✓ Webhook: ${WEBHOOK_URL}`);
+
+  console.log(
+    "\n=== Paste these into Vercel → Settings → Environment Variables ===",
+  );
+  console.log(`STRIPE_PRICE_PLUS=${out.plus}`);
+  console.log(`STRIPE_PRICE_STUDENT=${out.student}`);
+  console.log(`STRIPE_WEBHOOK_SECRET=${whsec}`);
+  console.log(`APP_BASE_URL=${APP_BASE_URL}`);
+  console.log(`STRIPE_SECRET_KEY=<the ${live ? "live" : "test"} key you used>`);
+}
+
+main().catch((e) => {
+  console.error("Stripe setup failed:", e.message);
+  process.exit(1);
+});

--- a/supabase/migrations/0001_subscriptions.sql
+++ b/supabase/migrations/0001_subscriptions.sql
@@ -1,0 +1,49 @@
+-- 0001_subscriptions.sql
+-- CaseDive monetization: per-user subscription state.
+-- Run in the Supabase SQL editor (no migration CLI is wired into this repo yet).
+--
+-- The Stripe webhook (service role) is the SOLE writer. The webhook is the source
+-- of truth for plan/status; clients may only read their own row via RLS.
+
+create table if not exists public.subscriptions (
+  user_id                uuid primary key references auth.users (id) on delete cascade,
+  stripe_customer_id     text unique,
+  stripe_subscription_id text unique,
+  plan                   text not null default 'free'
+                           check (plan in ('free', 'plus', 'student')),
+  status                 text not null default 'inactive'
+                           check (status in ('inactive', 'active', 'trialing',
+                                             'past_due', 'canceled')),
+  current_period_end     timestamptz,
+  created_at             timestamptz not null default now(),
+  updated_at             timestamptz not null default now()
+);
+
+-- Lookups by Stripe customer id (webhook maps customer -> user).
+create index if not exists subscriptions_stripe_customer_id_idx
+  on public.subscriptions (stripe_customer_id);
+
+-- Row Level Security: a user can read only their own row.
+-- No client INSERT/UPDATE/DELETE policy is granted, so all writes must use the
+-- service role key (the Stripe webhook), bypassing RLS by design.
+alter table public.subscriptions enable row level security;
+
+drop policy if exists "subscriptions_select_own" on public.subscriptions;
+create policy "subscriptions_select_own"
+  on public.subscriptions
+  for select
+  using (auth.uid() = user_id);
+
+-- Keep updated_at fresh on every write.
+create or replace function public.set_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists subscriptions_set_updated_at on public.subscriptions;
+create trigger subscriptions_set_updated_at
+  before update on public.subscriptions
+  for each row execute function public.set_updated_at();

--- a/tests/unit/billingApi.test.js
+++ b/tests/unit/billingApi.test.js
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Shared mocks ──────────────────────────────────────────────────────────────
+const mockCheckRequestRateLimit = vi.fn(async () => ({
+  result: { allowed: true, limit: 100, remaining: 99 },
+  identity: "user:u1",
+}));
+const mockGetAuthedUser = vi.fn();
+const mockGetServiceClient = vi.fn();
+const mockGetBearerToken = vi.fn(() => "tok");
+
+const mockStripe = {
+  checkout: { sessions: { create: vi.fn() } },
+  billingPortal: { sessions: { create: vi.fn() } },
+  subscriptions: { retrieve: vi.fn() },
+  webhooks: { constructEvent: vi.fn() },
+};
+const mockIsStripeConfigured = vi.fn(() => true);
+
+vi.mock("../../api/_subscription.js", () => ({
+  checkRequestRateLimit: mockCheckRequestRateLimit,
+  getAuthedUser: mockGetAuthedUser,
+  getServiceClient: mockGetServiceClient,
+  getBearerToken: mockGetBearerToken,
+}));
+
+vi.mock("../../api/_stripe.js", () => ({
+  getStripe: () => mockStripe,
+  isStripeConfigured: mockIsStripeConfigured,
+  planToPriceId: (plan) => (plan === "plus" ? "price_plus" : null),
+  priceToPlan: (id) => (id === "price_plus" ? "plus" : null),
+  CHECKOUT_PLANS: new Set(["plus", "student"]),
+}));
+
+vi.mock("../../api/_rateLimit.js", () => ({
+  rateLimitHeaders: () => ({ "X-RateLimit-Limit": "100" }),
+}));
+
+vi.mock("../../api/_logging.js", () => ({
+  logRequestStart: vi.fn(),
+  logRateLimitCheck: vi.fn(),
+  logValidationError: vi.fn(),
+  logExternalApiCall: vi.fn(),
+  logSuccess: vi.fn(),
+  logError: vi.fn(),
+}));
+
+vi.mock("../../api/_cors.js", () => ({
+  applyCorsHeaders: vi.fn(),
+  isOriginAllowed: () => true,
+}));
+
+const { default: checkoutHandler } = await import(
+  "../../api/create-checkout-session.js"
+);
+const { default: webhookHandler } = await import("../../api/stripe-webhook.js");
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+function createRes() {
+  return {
+    statusCode: null,
+    headers: {},
+    body: null,
+    setHeader(k, v) {
+      this.headers[k] = v;
+    },
+    status(c) {
+      this.statusCode = c;
+      return this;
+    },
+    json(p) {
+      this.body = p;
+      return this;
+    },
+    end() {
+      return this;
+    },
+  };
+}
+
+function checkoutReq({ body = {}, headers = {} } = {}) {
+  return {
+    method: "POST",
+    body,
+    headers: { "content-type": "application/json", ...headers },
+  };
+}
+
+// Webhook req is an async-iterable stream (handler reads the raw body).
+function webhookReq({ rawBody = "{}", headers = {} } = {}) {
+  return {
+    method: "POST",
+    headers: { "stripe-signature": "sig", ...headers },
+    async *[Symbol.asyncIterator]() {
+      yield Buffer.from(rawBody);
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsStripeConfigured.mockReturnValue(true);
+  process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+});
+
+afterEach(() => {
+  delete process.env.STRIPE_WEBHOOK_SECRET;
+});
+
+// ── create-checkout-session ─────────────────────────────────────────────────
+describe("create-checkout-session", () => {
+  it("503 when Stripe is not configured", async () => {
+    mockIsStripeConfigured.mockReturnValue(false);
+    const res = createRes();
+    await checkoutHandler(checkoutReq({ body: { plan: "plus" } }), res);
+    expect(res.statusCode).toBe(503);
+  });
+
+  it("401 when unauthenticated", async () => {
+    mockGetAuthedUser.mockResolvedValue(null);
+    const res = createRes();
+    await checkoutHandler(checkoutReq({ body: { plan: "plus" } }), res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("400 on an invalid plan", async () => {
+    mockGetAuthedUser.mockResolvedValue({ id: "u1", email: "a@b.co" });
+    const res = createRes();
+    await checkoutHandler(checkoutReq({ body: { plan: "enterprise" } }), res);
+    expect(res.statusCode).toBe(400);
+    expect(mockStripe.checkout.sessions.create).not.toHaveBeenCalled();
+  });
+
+  it("creates a session and returns its URL on the happy path", async () => {
+    mockGetAuthedUser.mockResolvedValue({ id: "u1", email: "a@b.co" });
+    mockStripe.checkout.sessions.create.mockResolvedValue({
+      url: "https://checkout.stripe.com/c/test",
+    });
+    const res = createRes();
+    await checkoutHandler(checkoutReq({ body: { plan: "plus" } }), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.url).toContain("checkout.stripe.com");
+    const arg = mockStripe.checkout.sessions.create.mock.calls[0][0];
+    expect(arg.mode).toBe("subscription");
+    expect(arg.line_items[0].price).toBe("price_plus");
+    expect(arg.client_reference_id).toBe("u1");
+    expect(arg.metadata.supabase_user_id).toBe("u1");
+  });
+});
+
+// ── stripe-webhook ────────────────────────────────────────────────────────────
+describe("stripe-webhook", () => {
+  it("400 when the signature header is missing", async () => {
+    const res = createRes();
+    await webhookHandler(
+      webhookReq({ headers: { "stripe-signature": undefined } }),
+      res,
+    );
+    expect(res.statusCode).toBe(400);
+    expect(mockStripe.webhooks.constructEvent).not.toHaveBeenCalled();
+  });
+
+  it("400 when signature verification fails", async () => {
+    mockStripe.webhooks.constructEvent.mockImplementation(() => {
+      throw new Error("bad sig");
+    });
+    const res = createRes();
+    await webhookHandler(webhookReq(), res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("upserts a complete row and 200s on checkout.session.completed", async () => {
+    const upsert = vi.fn(async () => ({ error: null }));
+    mockGetServiceClient.mockReturnValue({
+      from: () => ({ upsert }),
+    });
+    mockStripe.webhooks.constructEvent.mockReturnValue({
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          subscription: "sub_1",
+          client_reference_id: "u1",
+          metadata: { supabase_user_id: "u1", plan: "plus" },
+        },
+      },
+    });
+    mockStripe.subscriptions.retrieve.mockResolvedValue({
+      id: "sub_1",
+      customer: "cus_1",
+      status: "active",
+      current_period_end: 1893456000,
+      items: { data: [{ price: { id: "price_plus" } }] },
+      metadata: { supabase_user_id: "u1", plan: "plus" },
+    });
+
+    const res = createRes();
+    await webhookHandler(webhookReq(), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(upsert).toHaveBeenCalledTimes(1);
+    const [row, opts] = upsert.mock.calls[0];
+    expect(opts).toEqual({ onConflict: "user_id" });
+    expect(row).toMatchObject({
+      user_id: "u1",
+      stripe_customer_id: "cus_1",
+      stripe_subscription_id: "sub_1",
+      plan: "plus",
+      status: "active",
+    });
+  });
+
+  it("maps an unrecognized Stripe status to 'inactive'", async () => {
+    const upsert = vi.fn(async () => ({ error: null }));
+    mockGetServiceClient.mockReturnValue({ from: () => ({ upsert }) });
+    mockStripe.webhooks.constructEvent.mockReturnValue({
+      type: "customer.subscription.updated",
+      data: {
+        object: {
+          id: "sub_1",
+          customer: "cus_1",
+          status: "incomplete",
+          items: { data: [{ price: { id: "price_plus" } }] },
+          metadata: { supabase_user_id: "u1" },
+        },
+      },
+    });
+    const res = createRes();
+    await webhookHandler(webhookReq(), res);
+    expect(res.statusCode).toBe(200);
+    expect(upsert.mock.calls[0][0].status).toBe("inactive");
+  });
+});

--- a/tests/unit/subscription.test.js
+++ b/tests/unit/subscription.test.js
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ORIGINAL_ENV = { ...process.env };
+
+const mockGetUser = vi.fn();
+const mockMaybeSingle = vi.fn();
+const mockCheckRateLimit = vi.fn(async (identity, endpoint, options) => ({
+  allowed: true,
+  limit: options?.limit ?? 0,
+  remaining: 0,
+  __identity: identity,
+}));
+const mockGetClientIp = vi.fn(() => "9.9.9.9");
+
+// Re-import the module fresh so the cached Supabase client and current env are
+// picked up per test (mirrors tests/unit/rateLimit.test.js).
+async function loadModule() {
+  vi.resetModules();
+  vi.doMock("@supabase/supabase-js", () => ({
+    createClient: () => ({
+      auth: { getUser: mockGetUser },
+      from: () => ({
+        select: () => ({
+          eq: () => ({ maybeSingle: mockMaybeSingle }),
+        }),
+      }),
+    }),
+  }));
+  vi.doMock("../../api/_rateLimit.js", () => ({
+    checkRateLimit: mockCheckRateLimit,
+    getClientIp: mockGetClientIp,
+  }));
+  return import("../../api/_subscription.js");
+}
+
+function reqWith(token) {
+  return { headers: token ? { authorization: `Bearer ${token}` } : {} };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.SUPABASE_URL = "https://example.supabase.co";
+  process.env.SUPABASE_SERVICE_KEY = "service-key";
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  vi.doUnmock("@supabase/supabase-js");
+  vi.doUnmock("../../api/_rateLimit.js");
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe("plan limit config", () => {
+  it("maps each plan to its hourly abuse limit; free matches the legacy anon cap", async () => {
+    const m = await loadModule();
+    expect(m.getHourlyRateLimit("free")).toBe(5);
+    expect(m.getHourlyRateLimit("plus")).toBe(100);
+    expect(m.getHourlyRateLimit("student")).toBe(100);
+  });
+
+  it("falls back to the free limit for an unknown plan", async () => {
+    const m = await loadModule();
+    expect(m.getHourlyRateLimit("enterprise")).toBe(5);
+    expect(m.getPlanLimits("nonsense").label).toBe("Free");
+  });
+});
+
+describe("getBearerToken", () => {
+  it("extracts a Bearer token and returns null otherwise", async () => {
+    const m = await loadModule();
+    expect(m.getBearerToken({ headers: { authorization: "Bearer abc" } })).toBe(
+      "abc",
+    );
+    expect(m.getBearerToken({ headers: { authorization: "Basic abc" } })).toBe(
+      null,
+    );
+    expect(m.getBearerToken({ headers: {} })).toBe(null);
+    expect(m.getBearerToken({})).toBe(null);
+  });
+});
+
+describe("resolvePlan", () => {
+  it("returns free for an anonymous request without touching Supabase", async () => {
+    const m = await loadModule();
+    expect(await m.resolvePlan(null)).toBe("free");
+    expect(mockGetUser).not.toHaveBeenCalled();
+  });
+
+  it("returns free when Supabase is not configured", async () => {
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_KEY;
+    const m = await loadModule();
+    expect(await m.resolvePlan("some-token")).toBe("free");
+  });
+
+  it("returns the paid plan for an active subscriber", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } }, error: null });
+    mockMaybeSingle.mockResolvedValue({
+      data: { plan: "plus", status: "active" },
+      error: null,
+    });
+    const m = await loadModule();
+    expect(await m.resolvePlan("tok")).toBe("plus");
+  });
+
+  it("downgrades a non-entitled status (e.g. past_due) to free", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } }, error: null });
+    mockMaybeSingle.mockResolvedValue({
+      data: { plan: "plus", status: "past_due" },
+      error: null,
+    });
+    const m = await loadModule();
+    expect(await m.resolvePlan("tok")).toBe("free");
+  });
+
+  it("degrades to free on an auth error", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: "bad" } });
+    const m = await loadModule();
+    expect(await m.resolvePlan("tok")).toBe("free");
+  });
+
+  it("degrades to free if the subscriptions lookup throws", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } }, error: null });
+    mockMaybeSingle.mockRejectedValue(new Error("db down"));
+    const m = await loadModule();
+    expect(await m.resolvePlan("tok")).toBe("free");
+  });
+});
+
+describe("checkRequestRateLimit", () => {
+  it("keys anonymous requests on the client IP with the free limit", async () => {
+    const m = await loadModule();
+    const { result, identity, plan } = await m.checkRequestRateLimit(
+      reqWith(null),
+      "analyze",
+    );
+    expect(identity).toBe("9.9.9.9");
+    expect(plan).toBe("free");
+    expect(mockCheckRateLimit).toHaveBeenCalledWith("9.9.9.9", "analyze", {
+      limit: 5,
+    });
+    expect(result.limit).toBe(5);
+  });
+
+  it("keys an authenticated paid user on user:<id> with the plan limit", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u42" } }, error: null });
+    mockMaybeSingle.mockResolvedValue({
+      data: { plan: "plus", status: "active" },
+      error: null,
+    });
+    const m = await loadModule();
+    const { identity, plan, userId } = await m.checkRequestRateLimit(
+      reqWith("tok"),
+      "analyze",
+    );
+    expect(userId).toBe("u42");
+    expect(plan).toBe("plus");
+    expect(identity).toBe("user:u42");
+    expect(mockCheckRateLimit).toHaveBeenCalledWith("user:u42", "analyze", {
+      limit: 100,
+    });
+    // A real IP can never collide with the user namespace.
+    expect(mockGetClientIp).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What
Monetization foundation for CaseDive — B2C freemium on Stripe (test-mode wired). Phases 1–3 of `docs/monetization-plan.md`.

## Changes
- **DB:** `subscriptions` table — RLS select-own; the Stripe webhook (service role) is the sole writer.
- **Plan-aware rate limiting:** auth requests keyed on Supabase user id; anonymous stay IP-keyed at **5/hr (unchanged)**. Supabase reads timeout-guarded.
- **`_rateLimit.js`:** optional per-call `limit` override (backward compatible).
- **Endpoints:** `analyze`, `case-summary`, `export-pdf`, `verify` use `checkRequestRateLimit`.
- **Stripe:** `create-checkout-session`, `billing-portal`, `stripe-webhook` (raw body + signature verify + complete-row upserts) + `_stripe.js`. Degrade to **503** until env vars exist.
- **Tooling:** `scripts/stripe-setup.mjs`.

## Tests
New: `subscription.test.js` (11), `billingApi.test.js` (8). Full unit suite **286/286**, build clean, gitleaks clean.

## ⚠️ Post-deploy
- Verify webhook raw-body on Vercel: a signed event must return non-`400`.
- Do NOT switch Stripe to live keys until ToS + disclaimer + CanLII license are done (plan §6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)