### PR TITLE
fix(billing): correct logging arg order/args (prod 500 crash)

### DIFF
--- a/api/billing.js
+++ b/api/billing.js
@@ -45,7 +45,7 @@ function resolveBaseUrl() {
   return process.env.APP_BASE_URL || "https://www.casedive.ca";
 }
 
-async function handleCheckout(req, res, requestId, user) {
+async function handleCheckout(req, res, { requestId, startMs, rlResult, user }) {
   const plan = req.body?.plan;
   if (!CHECKOUT_PLANS.has(plan)) {
     logValidationError(requestId, "billing", "Invalid plan", "plan");
@@ -53,7 +53,13 @@ async function handleCheckout(req, res, requestId, user) {
   }
   const priceId = planToPriceId(plan);
   if (!priceId) {
-    logError(requestId, "billing", "Price id not configured");
+    logError(
+      requestId,
+      "billing",
+      new Error("Price id not configured"),
+      503,
+      Date.now() - startMs,
+    );
     return res.status(503).json({ error: "Billing is not available" });
   }
 
@@ -71,15 +77,15 @@ async function handleCheckout(req, res, requestId, user) {
       success_url: `${baseUrl}/?checkout=success`,
       cancel_url: `${baseUrl}/?checkout=cancelled`,
     });
-    logSuccess(requestId, "billing");
+    logSuccess(requestId, "billing", 200, Date.now() - startMs, rlResult);
     return res.status(200).json({ url: session.url });
   } catch (err) {
-    logError(requestId, "billing", err.message);
+    logError(requestId, "billing", err, 502, Date.now() - startMs);
     return res.status(502).json({ error: "Failed to start checkout" });
   }
 }
 
-async function handlePortal(req, res, requestId, user) {
+async function handlePortal(req, res, { requestId, startMs, rlResult, user }) {
   const supabase = getServiceClient();
   if (!supabase) {
     return res.status(503).json({ error: "Billing is not available" });
@@ -94,7 +100,7 @@ async function handlePortal(req, res, requestId, user) {
       .maybeSingle();
     if (!error) customerId = data?.stripe_customer_id ?? null;
   } catch (err) {
-    logError(requestId, "billing", err.message);
+    logError(requestId, "billing", err, 500, Date.now() - startMs);
   }
   if (!customerId) {
     return res.status(404).json({ error: "No active subscription" });
@@ -106,16 +112,17 @@ async function handlePortal(req, res, requestId, user) {
       customer: customerId,
       return_url: resolveBaseUrl(),
     });
-    logSuccess(requestId, "billing");
+    logSuccess(requestId, "billing", 200, Date.now() - startMs, rlResult);
     return res.status(200).json({ url: session.url });
   } catch (err) {
-    logError(requestId, "billing", err.message);
+    logError(requestId, "billing", err, 502, Date.now() - startMs);
     return res.status(502).json({ error: "Failed to open billing portal" });
   }
 }
 
 export default async function handler(req, res) {
   const requestId = randomUUID();
+  const startMs = Date.now();
   applyStandardApiHeaders(
     req,
     res,
@@ -124,7 +131,7 @@ export default async function handler(req, res) {
   );
   if (handleOptionsAndMethod(req, res, "POST")) return;
 
-  logRequestStart(requestId, "billing", req);
+  logRequestStart(req, "billing", requestId);
 
   if (!isStripeConfigured()) {
     return res.status(503).json({ error: "Billing is not available" });
@@ -156,9 +163,10 @@ export default async function handler(req, res) {
     return;
   }
 
+  const ctx = { requestId, startMs, rlResult, user };
   const action = req.body?.action;
-  if (action === "checkout") return handleCheckout(req, res, requestId, user);
-  if (action === "portal") return handlePortal(req, res, requestId, user);
+  if (action === "checkout") return handleCheckout(req, res, ctx);
+  if (action === "portal") return handlePortal(req, res, ctx);
 
   logValidationError(requestId, "billing", "Invalid action", "action");
   return res.status(400).json({ error: "Invalid action" });

--- a/api/stripe-webhook.js
+++ b/api/stripe-webhook.js
@@ -93,6 +93,7 @@ function applyWebhookHeaders(res) {
 
 export default async function handler(req, res) {
   const requestId = randomUUID();
+  const startMs = Date.now();
   applyWebhookHeaders(res);
 
   if (req.method !== "POST") {
@@ -109,7 +110,7 @@ export default async function handler(req, res) {
     return res.status(400).json({ error: "Missing signature" });
   }
 
-  logRequestStart(requestId, "stripe-webhook", req);
+  logRequestStart(req, "stripe-webhook", requestId);
 
   // 1) Verify signature against the raw body. Forged/unsigned -> 400.
   let event;
@@ -121,14 +122,20 @@ export default async function handler(req, res) {
       process.env.STRIPE_WEBHOOK_SECRET,
     );
   } catch (err) {
-    logError(requestId, "stripe-webhook", `signature: ${err.message}`);
+    logError(requestId, "stripe-webhook", err, 400, Date.now() - startMs);
     return res.status(400).json({ error: "Invalid signature" });
   }
 
   const supabase = getServiceClient();
   if (!supabase) {
     // Can't persist; 500 so Stripe retries once Supabase is configured.
-    logError(requestId, "stripe-webhook", "Supabase not configured");
+    logError(
+      requestId,
+      "stripe-webhook",
+      new Error("Supabase not configured"),
+      500,
+      Date.now() - startMs,
+    );
     return res.status(500).json({ error: "Store unavailable" });
   }
 
@@ -176,11 +183,14 @@ export default async function handler(req, res) {
         break;
     }
   } catch (err) {
-    logError(requestId, "stripe-webhook", err.message);
+    logError(requestId, "stripe-webhook", err, 500, Date.now() - startMs);
     // 500 -> Stripe retries with backoff (writes are idempotent upserts).
     return res.status(500).json({ error: "Failed to process event" });
   }
 
-  logSuccess(requestId, "stripe-webhook");
+  // No rate limiter on this endpoint, so pass a stub rlResult to logSuccess.
+  logSuccess(requestId, "stripe-webhook", 200, Date.now() - startMs, {
+    remaining: null,
+  });
   return res.status(200).json({ received: true });
 }

--- a/tests/unit/billingApi.test.js
+++ b/tests/unit/billingApi.test.js
@@ -36,14 +36,9 @@ vi.mock("../../api/_rateLimit.js", () => ({
   rateLimitHeaders: () => ({ "X-RateLimit-Limit": "100" }),
 }));
 
-vi.mock("../../api/_logging.js", () => ({
-  logRequestStart: vi.fn(),
-  logRateLimitCheck: vi.fn(),
-  logValidationError: vi.fn(),
-  logExternalApiCall: vi.fn(),
-  logSuccess: vi.fn(),
-  logError: vi.fn(),
-}));
+// NB: _logging is intentionally NOT mocked. The real logging helpers have
+// strict arg orders (e.g. logRequestStart(req, ...), logSuccess(..., rlResult))
+// that a mock silently swallows — running them for real catches those bugs.
 
 vi.mock("../../api/_cors.js", () => ({
   applyCorsHeaders: vi.fn(),
@@ -79,8 +74,10 @@ function createRes() {
 function checkoutReq({ body = {}, headers = {} } = {}) {
   return {
     method: "POST",
+    url: "/api/billing",
     body,
     headers: { "content-type": "application/json", ...headers },
+    socket: { remoteAddress: "127.0.0.1" },
   };
 }
 
@@ -88,7 +85,9 @@ function checkoutReq({ body = {}, headers = {} } = {}) {
 function webhookReq({ rawBody = "{}", headers = {} } = {}) {
   return {
     method: "POST",
+    url: "/api/stripe-webhook",
     headers: { "stripe-signature": "sig", ...headers },
+    socket: { remoteAddress: "127.0.0.1" },
     async *[Symbol.asyncIterator]() {
       yield Buffer.from(rawBody);
     },


### PR DESCRIPTION
The deployed webhook crashed with **FUNCTION_INVOCATION_FAILED (500)** on POST.

Root cause: the new billing/webhook endpoints called `logRequestStart(requestId, endpoint, req)`, but the real signature is `logRequestStart(req, endpoint, requestId)` — so `req` was a string and `req.headers[...]` threw. `logSuccess` also reads `rlResult.remaining`, which was omitted. The unit tests mocked `_logging`, so they never exercised the real signatures.

- Fix `logRequestStart` order; pass `statusCode/duration/rlResult` to `logSuccess`; pass `Error + status` to `logError` in `billing.js` + `stripe-webhook.js`.
- Stop mocking `_logging` in `billingApi.test.js` (give fake reqs a `socket`/`url`) so this class of bug is caught by the suite, not production.
- Full unit suite 287/287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)